### PR TITLE
fix: improve hledger binary detection for GUI launch

### DIFF
--- a/hledger-macos/Backend/BinaryDetector.swift
+++ b/hledger-macos/Backend/BinaryDetector.swift
@@ -12,11 +12,19 @@ struct BinaryDetectionResult: Sendable {
 /// Scans for the hledger binary in known paths, user shell PATH, and configured locations.
 enum BinaryDetector {
     /// Common installation paths on macOS.
-    private static let knownPaths = [
-        "/opt/homebrew/bin/hledger",    // Apple Silicon Homebrew
-        "/usr/local/bin/hledger",       // Intel Homebrew
-        "/usr/bin/hledger",             // System
-    ]
+    private static var knownPaths: [String] {
+        let home = FileManager.default.homeDirectoryForCurrentUser.path
+        return [
+            "/opt/homebrew/bin/hledger",          // Apple Silicon Homebrew
+            "/usr/local/bin/hledger",             // Intel Homebrew
+            "/usr/bin/hledger",                   // System
+            "\(home)/.local/bin/hledger",         // stack install
+            "\(home)/.ghcup/bin/hledger",         // ghcup
+            "\(home)/.cabal/bin/hledger",         // cabal install
+            "/nix/var/nix/profiles/default/bin/hledger",  // Nix system
+            "\(home)/.nix-profile/bin/hledger",   // Nix user
+        ]
+    }
 
     /// Detect the hledger binary.
     static func detect(customHledgerPath: String = "") -> BinaryDetectionResult {
@@ -55,26 +63,39 @@ enum BinaryDetector {
     private static func shellPATHDirectories() -> [String] {
         let shell = ProcessInfo.processInfo.environment["SHELL"] ?? "/bin/zsh"
 
-        let process = Process()
-        process.executableURL = URL(fileURLWithPath: shell)
-        process.arguments = ["-l", "-c", "echo $PATH"]
+        // Try both interactive login (-li) and plain login (-l) for maximum compatibility
+        for args in [["-li", "-c", "echo $PATH"], ["-l", "-c", "echo $PATH"]] {
+            let process = Process()
+            process.executableURL = URL(fileURLWithPath: shell)
+            process.arguments = args
 
-        let pipe = Pipe()
-        process.standardOutput = pipe
-        process.standardError = Pipe()
+            let pipe = Pipe()
+            process.standardOutput = pipe
+            process.standardError = Pipe()
 
-        do {
-            try process.run()
-            process.waitUntilExit()
+            do {
+                try process.run()
+                // Timeout after 5 seconds to avoid hanging on interactive shells
+                let deadline = DispatchTime.now() + .seconds(5)
+                let done = DispatchSemaphore(value: 0)
+                process.terminationHandler = { _ in done.signal() }
+                if done.wait(timeout: deadline) == .timedOut {
+                    process.terminate()
+                    continue
+                }
 
-            let data = pipe.fileHandleForReading.readDataToEndOfFile()
-            guard let pathString = String(data: data, encoding: .utf8)?
-                .trimmingCharacters(in: .whitespacesAndNewlines),
-                  !pathString.isEmpty else { return [] }
-
-            return pathString.split(separator: ":").map(String.init)
-        } catch {
-            return []
+                let data = pipe.fileHandleForReading.readDataToEndOfFile()
+                guard let output = String(data: data, encoding: .utf8) else { continue }
+                // Take last non-empty line (shell might print motd or other output)
+                let pathString = output.split(separator: "\n")
+                    .map { $0.trimmingCharacters(in: .whitespaces) }
+                    .last { $0.contains("/") && !$0.isEmpty }
+                guard let pathString, !pathString.isEmpty else { continue }
+                return pathString.split(separator: ":").map(String.init)
+            } catch {
+                continue
+            }
         }
+        return []
     }
 }


### PR DESCRIPTION
Fixes #9

- Added Haskell toolchain paths (~/.local/bin, ~/.ghcup/bin, ~/.cabal/bin, Nix)
- Improved shell PATH resolution with interactive login shell and timeout
- Parse last PATH-like line from shell output to skip motd/banners