### PR TITLE
feat: add command log for debugging hledger commands

### DIFF
--- a/hledger-macos/Backend/SubprocessRunner.swift
+++ b/hledger-macos/Backend/SubprocessRunner.swift
@@ -80,6 +80,16 @@ actor SubprocessRunner {
                 let outStr = String(data: outData, encoding: .utf8) ?? ""
                 let errStr = String(data: errData, encoding: .utf8) ?? ""
 
+                let cmd = ([process.executableURL?.lastPathComponent ?? "?"] + (process.arguments ?? [])).joined(separator: " ")
+                Task { @MainActor in
+                    CommandLog.shared.log(
+                        command: cmd,
+                        exitCode: process.terminationStatus,
+                        stdout: outStr,
+                        stderr: errStr
+                    )
+                }
+
                 if process.terminationStatus == 0 {
                     continuation.resume(returning: outStr)
                 } else {

--- a/hledger-macos/Services/CommandLog.swift
+++ b/hledger-macos/Services/CommandLog.swift
@@ -1,0 +1,56 @@
+/// Centralized log of all hledger commands executed by the app.
+
+import Foundation
+
+/// A single logged command execution.
+struct CommandLogEntry: Identifiable, Hashable {
+    static func == (lhs: CommandLogEntry, rhs: CommandLogEntry) -> Bool { lhs.id == rhs.id }
+    func hash(into hasher: inout Hasher) { hasher.combine(id) }
+
+    let id = UUID()
+    let timestamp: Date
+    let command: String
+    let exitCode: Int32
+    let stdout: String
+    let stderr: String
+
+    var isError: Bool { exitCode != 0 }
+
+    var timestampFormatted: String {
+        let f = DateFormatter()
+        f.dateFormat = "HH:mm:ss.SSS"
+        return f.string(from: timestamp)
+    }
+}
+
+/// Observable command log shared across the app.
+@Observable
+@MainActor
+final class CommandLog {
+    static let shared = CommandLog()
+
+    private(set) var entries: [CommandLogEntry] = []
+
+    func log(command: String, exitCode: Int32, stdout: String, stderr: String) {
+        let entry = CommandLogEntry(
+            timestamp: Date(),
+            command: command,
+            exitCode: exitCode,
+            stdout: stdout,
+            stderr: stderr
+        )
+        entries.append(entry)
+        // Keep last 500 entries
+        if entries.count > 500 {
+            entries.removeFirst(entries.count - 500)
+        }
+    }
+
+    func clear() {
+        entries.removeAll()
+    }
+
+    var errorCount: Int {
+        entries.count(where: \.isError)
+    }
+}

--- a/hledger-macos/Views/MainWindow/CommandLogView.swift
+++ b/hledger-macos/Views/MainWindow/CommandLogView.swift
@@ -1,0 +1,135 @@
+/// Debug panel showing all hledger commands executed during this session.
+
+import SwiftUI
+
+struct CommandLogView: View {
+    @Environment(\.dismiss) private var dismiss
+    @State private var selectedEntry: CommandLogEntry?
+    private let log = CommandLog.shared
+
+    var body: some View {
+        VStack(spacing: 0) {
+            // Header
+            HStack {
+                Text("Command Log")
+                    .font(.headline)
+                Text("\(log.entries.count) commands")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                if log.errorCount > 0 {
+                    Text("\(log.errorCount) errors")
+                        .font(.caption)
+                        .foregroundStyle(.red)
+                }
+                Spacer()
+                Button("Clear") { log.clear() }
+                    .controlSize(.small)
+            }
+            .padding(.horizontal, 16)
+            .padding(.vertical, 12)
+
+            Divider()
+
+            if log.entries.isEmpty {
+                Spacer()
+                Text("No commands executed yet.")
+                    .foregroundStyle(.secondary)
+                Spacer()
+            } else {
+                HSplitView {
+                    // Command list
+                    List(log.entries.reversed(), selection: $selectedEntry) { entry in
+                        HStack(spacing: 8) {
+                            Image(systemName: entry.isError ? "xmark.circle.fill" : "checkmark.circle.fill")
+                                .foregroundStyle(entry.isError ? .red : .green)
+                                .font(.caption)
+
+                            Text(entry.timestampFormatted)
+                                .font(.system(.caption, design: .monospaced))
+                                .foregroundStyle(.secondary)
+
+                            Text(entry.command)
+                                .font(.system(.caption, design: .monospaced))
+                                .lineLimit(1)
+                                .truncationMode(.middle)
+                        }
+                        .tag(entry)
+                        .padding(.vertical, 2)
+                    }
+                    .listStyle(.inset)
+                    .frame(minWidth: 400)
+
+                    // Detail panel
+                    if let entry = selectedEntry {
+                        entryDetail(entry)
+                            .frame(minWidth: 300)
+                    } else {
+                        VStack {
+                            Spacer()
+                            Text("Select a command to view details")
+                                .foregroundStyle(.secondary)
+                            Spacer()
+                        }
+                        .frame(minWidth: 300)
+                    }
+                }
+            }
+
+            Divider()
+
+            HStack {
+                Spacer()
+                Button("Done") { dismiss() }
+                    .keyboardShortcut(.defaultAction)
+            }
+            .padding(.horizontal, 16)
+            .padding(.vertical, 10)
+        }
+        .frame(width: 900, height: 500)
+    }
+
+    private func entryDetail(_ entry: CommandLogEntry) -> some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 12) {
+                detailSection("Command", entry.command)
+
+                HStack(spacing: 16) {
+                    detailLabel("Exit Code", "\(entry.exitCode)", color: entry.isError ? .red : .green)
+                    detailLabel("Time", entry.timestampFormatted, color: .secondary)
+                }
+
+                if !entry.stderr.isEmpty {
+                    detailSection("stderr", entry.stderr, color: .red)
+                }
+
+                if !entry.stdout.isEmpty {
+                    detailSection("stdout", String(entry.stdout.prefix(2000)))
+                }
+            }
+            .padding(16)
+        }
+    }
+
+    private func detailSection(_ title: String, _ content: String, color: Color = .primary) -> some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(title)
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(.secondary)
+            Text(content)
+                .font(.system(.caption, design: .monospaced))
+                .foregroundStyle(color)
+                .textSelection(.enabled)
+        }
+    }
+
+    private func detailLabel(_ title: String, _ value: String, color: Color) -> some View {
+        VStack(alignment: .leading, spacing: 2) {
+            Text(title)
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(.secondary)
+            Text(value)
+                .font(.system(.caption, design: .monospaced))
+                .foregroundStyle(color)
+        }
+    }
+}

--- a/hledger-macos/hledger_macosApp.swift
+++ b/hledger-macos/hledger_macosApp.swift
@@ -6,6 +6,7 @@ import SwiftUI
 struct hledger_macosApp: App {
     @State private var appState = AppState()
     @State private var showingShortcuts = false
+    @State private var showingCommandLog = false
     @State private var updateStatus: UpdateStatus?
     @State private var showingUpdateAlert = false
 
@@ -49,6 +50,9 @@ struct hledger_macosApp: App {
             .sheet(isPresented: $showingShortcuts) {
                 ShortcutsView()
             }
+            .sheet(isPresented: $showingCommandLog) {
+                CommandLogView()
+            }
             .alert("Update Available", isPresented: $showingUpdateAlert) {
                 if case .updateAvailable(_, let url, let downloadUrl) = updateStatus {
                     if let downloadUrl {
@@ -75,7 +79,7 @@ struct hledger_macosApp: App {
             }
         }
         .commands {
-            AppCommands(appState: appState, showingShortcuts: $showingShortcuts, checkForUpdate: {
+            AppCommands(appState: appState, showingShortcuts: $showingShortcuts, showingCommandLog: $showingCommandLog, checkForUpdate: {
                 Task {
                     updateStatus = await UpdateChecker.check()
                     showingUpdateAlert = true
@@ -94,6 +98,7 @@ struct hledger_macosApp: App {
 struct AppCommands: Commands {
     let appState: AppState
     @Binding var showingShortcuts: Bool
+    @Binding var showingCommandLog: Bool
     var checkForUpdate: () -> Void
 
     var body: some Commands {
@@ -135,12 +140,17 @@ struct AppCommands: Commands {
             }
         }
 
-        // Help > Keyboard Shortcuts
+        // Help > Keyboard Shortcuts & Command Log
         CommandGroup(after: .help) {
             Button("Keyboard Shortcuts") {
                 showingShortcuts = true
             }
             .keyboardShortcut("/", modifiers: .command)
+
+            Button("Command Log") {
+                showingCommandLog = true
+            }
+            .keyboardShortcut("l", modifiers: [.command, .option])
         }
 
         SidebarCommands()


### PR DESCRIPTION
Fixes #11

- CommandLog singleton captures every hledger command (timestamp, exit code, stdout, stderr)
- CommandLogView accessible via Help > Command Log (Cmd+Opt+L)
- Errors highlighted in red