### PR TITLE
feat: double-click transaction row to edit

### DIFF
--- a/hledger-macos/Views/Transactions/TransactionsView.swift
+++ b/hledger-macos/Views/Transactions/TransactionsView.swift
@@ -203,6 +203,7 @@ struct TransactionsView: View {
     private func transactionRow(_ transaction: Transaction) -> some View {
         TransactionRowView(transaction: transaction)
             .tag(transaction)
+            .onTapGesture(count: 2) { editTransaction(transaction) }
             .contextMenu {
                 Button("Edit") { editTransaction(transaction) }
                 Button("Clone") { cloneTransaction(transaction) }


### PR DESCRIPTION
Fixes #13

Added onTapGesture(count: 2) on transaction rows to open edit form.