### PR TITLE
fix: status toggle edits only date line instead of full replace

### DIFF
--- a/hledger-macos/Backend/AccountingBackend.swift
+++ b/hledger-macos/Backend/AccountingBackend.swift
@@ -79,6 +79,7 @@ protocol AccountingBackend: Sendable {
     // MARK: - Write
 
     func appendTransaction(_ transaction: Transaction) async throws
+    func updateTransactionStatus(_ transaction: Transaction, to newStatus: TransactionStatus) async throws
     func replaceTransaction(_ original: Transaction, with new: Transaction) async throws
     func deleteTransaction(_ transaction: Transaction) async throws
 }

--- a/hledger-macos/Backend/HledgerBackend.swift
+++ b/hledger-macos/Backend/HledgerBackend.swift
@@ -305,6 +305,15 @@ final class HledgerBackend: AccountingBackend, @unchecked Sendable {
         )
     }
 
+    func updateTransactionStatus(_ transaction: Transaction, to newStatus: TransactionStatus) async throws {
+        try await JournalWriter.updateStatus(
+            transaction: transaction,
+            newStatus: newStatus,
+            mainJournal: journalFile,
+            validator: self
+        )
+    }
+
     func replaceTransaction(_ original: Transaction, with new: Transaction) async throws {
         try await JournalWriter.replace(
             original: original,

--- a/hledger-macos/Backend/JournalWriter.swift
+++ b/hledger-macos/Backend/JournalWriter.swift
@@ -129,6 +129,59 @@ enum JournalWriter {
         }
     }
 
+    // MARK: - Status Toggle
+
+    /// Update only the status marker on a transaction's date line.
+    /// Much safer than full replace — doesn't re-format postings or amounts.
+    static func updateStatus(
+        transaction: Transaction,
+        newStatus: TransactionStatus,
+        mainJournal: URL,
+        validator: any AccountingBackend
+    ) async throws {
+        guard let startPos = transaction.sourcePosStart else {
+            throw BackendError.commandFailed("Cannot update status without source position")
+        }
+
+        let sourceFile = URL(fileURLWithPath: startPos.sourceName)
+        let backup = backupPath(for: sourceFile)
+
+        try createBackup(source: sourceFile, backup: backup)
+
+        do {
+            var lines = try String(contentsOf: sourceFile, encoding: .utf8)
+                .components(separatedBy: "\n")
+
+            let lineIndex = startPos.sourceLine - 1
+            guard lineIndex >= 0 && lineIndex < lines.count else {
+                throw BackendError.commandFailed("Transaction source line out of range")
+            }
+
+            let dateLine = lines[lineIndex]
+            // Date line format: "2024-01-01 [*|!] [(code)] description [; comment]"
+            // Match date, then optional status marker
+            let pattern = /^(\d{4}-\d{2}-\d{2})\s+([*!]\s+)?(.*)$/
+            guard let match = dateLine.wholeMatch(of: pattern) else {
+                throw BackendError.commandFailed("Cannot parse transaction date line")
+            }
+
+            let date = String(match.1)
+            let rest = String(match.3)
+            let statusStr = newStatus == .unmarked ? "" : "\(newStatus.symbol) "
+
+            lines[lineIndex] = "\(date) \(statusStr)\(rest)"
+
+            try lines.joined(separator: "\n").write(to: sourceFile, atomically: true, encoding: .utf8)
+            try await validate(mainJournal: mainJournal, sourceFile: sourceFile, backup: backup, validator: validator)
+        } catch let error as BackendError {
+            throw error
+        } catch {
+            restoreBackup(source: sourceFile, backup: backup)
+            cleanupBackup(backup)
+            throw BackendError.commandFailed("Failed to update status: \(error.localizedDescription)")
+        }
+    }
+
     // MARK: - Delete
 
     /// Delete a transaction from the journal using source positions.

--- a/hledger-macos/Views/Transactions/TransactionsView.swift
+++ b/hledger-macos/Views/Transactions/TransactionsView.swift
@@ -257,10 +257,8 @@ struct TransactionsView: View {
 
     private func toggleStatus(_ transaction: Transaction, to newStatus: TransactionStatus) async {
         guard let backend = appState.activeBackend else { return }
-        var updated = transaction
-        updated.status = newStatus
         do {
-            try await backend.replaceTransaction(transaction, with: updated)
+            try await backend.updateTransactionStatus(transaction, to: newStatus)
             await appState.loadTransactions()
         } catch {
             appState.errorMessage = error.localizedDescription


### PR DESCRIPTION
Fixes #14

New updateStatus() method modifies only the status marker on the date line via regex, preserving original journal formatting.