### PR TITLE
fix: detect contra-balances regardless of currency symbol position

### DIFF
--- a/hledger-macos/Views/Reports/ReportsView.swift
+++ b/hledger-macos/Views/Reports/ReportsView.swift
@@ -155,10 +155,14 @@ struct ReportsView: View {
         return trimmed
     }
 
+    private func isNegativeAmount(_ text: String) -> Bool {
+        text.contains("-")
+    }
+
     private func amountColor(_ amount: String, isTotal: Bool) -> Color {
         let trimmed = amount.trimmingCharacters(in: .whitespaces)
         if trimmed.isEmpty || trimmed == "0" { return .gray }
-        if trimmed.hasPrefix("-") { return .red }
+        if isNegativeAmount(trimmed) { return .red }
         if isTotal { return .primary }
         return .secondary
     }


### PR DESCRIPTION
Fixes #15

Uses contains("-") instead of hasPrefix("-") to correctly detect negative amounts when currency symbol precedes minus sign (e.g. €-100.00).