### PR TITLE
fix: double-click on full row and alphabetical sort in Summary

### DIFF
--- a/hledger-macos/Backend/HledgerBackend.swift
+++ b/hledger-macos/Backend/HledgerBackend.swift
@@ -200,7 +200,7 @@ final class HledgerBackend: AccountingBackend, @unchecked Sendable {
                 results.append((account, abs(qty), com))
             }
         }
-        return results.sorted { $0.1 > $1.1 }
+        return results.sorted { $0.0 < $1.0 }
     }
 
     /// Load expense breakdown for a period.

--- a/hledger-macos/Views/Transactions/TransactionsView.swift
+++ b/hledger-macos/Views/Transactions/TransactionsView.swift
@@ -203,6 +203,7 @@ struct TransactionsView: View {
     private func transactionRow(_ transaction: Transaction) -> some View {
         TransactionRowView(transaction: transaction)
             .tag(transaction)
+            .contentShape(Rectangle())
             .onTapGesture(count: 2) { editTransaction(transaction) }
             .contextMenu {
                 Button("Edit") { editTransaction(transaction) }


### PR DESCRIPTION
- Add contentShape(Rectangle()) so double-click works on entire transaction row
- Sort Summary breakdowns alphabetically by account name