### PR TITLE
fix: eliminate double refresh on Cmd+R and add Help wiki link

### DIFF
--- a/hledger-macos/Views/Transactions/TransactionsView.swift
+++ b/hledger-macos/Views/Transactions/TransactionsView.swift
@@ -159,7 +159,8 @@ struct TransactionsView: View {
                 newTransaction()
             }
         }
-        .task(id: appState.dataVersion) { await loadAll() }
+        .task { await loadAll() }
+        .task(id: appState.dataVersion) { await loadPeriodSummary() }
         .onChange(of: appState.currentPeriod) {
             Task { await loadAll() }
         }

--- a/hledger-macos/hledger_macosApp.swift
+++ b/hledger-macos/hledger_macosApp.swift
@@ -140,8 +140,14 @@ struct AppCommands: Commands {
             }
         }
 
-        // Help > Keyboard Shortcuts & Command Log
-        CommandGroup(after: .help) {
+        // Help > Keyboard Shortcuts, Command Log, Wiki
+        CommandGroup(replacing: .help) {
+            Button("hledger for Mac Help") {
+                NSWorkspace.shared.open(URL(string: "https://github.com/thesmokinator/hledger-macos/wiki")!)
+            }
+
+            Divider()
+
             Button("Keyboard Shortcuts") {
                 showingShortcuts = true
             }


### PR DESCRIPTION
- Fix double transaction reload on Cmd+R
- Replace default Help menu with link to GitHub wiki