### PR TITLE
fix(ci): use macos-26 runner to match deployment target

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ env:
 
 jobs:
   build:
-    runs-on: macos-15
+    runs-on: macos-26
     timeout-minutes: 30
 
     steps:


### PR DESCRIPTION
## Summary
- Upgrade CI runner from `macos-15` to `macos-26` to match the project's macOS 26.2 deployment target
- Fixes build #5 (`v0.1.0-rc5`) failure caused by SDK mismatch: Xcode 16.4 (SDK 15.5) cannot resolve Swift type-checker for code introduced in PR #25

## Test plan
- [ ] Merge and tag `v0.1.0-rc6` to verify the build passes on the new runner