### PR TITLE
fix: recurring rules missing currency and double-click edit

### DIFF
--- a/hledger-macos/Views/Recurring/RecurringFormView.swift
+++ b/hledger-macos/Views/Recurring/RecurringFormView.swift
@@ -8,6 +8,7 @@ struct RecurringFormView: View {
     let knownAccounts: [String]
     let onSave: (RecurringRule) -> Void
 
+    @Environment(AppState.self) private var appState
     @Environment(\.dismiss) private var dismiss
 
     @State private var periodExpr = "monthly"
@@ -192,9 +193,10 @@ struct RecurringFormView: View {
                 postings.append(Posting(account: row.account))
             } else {
                 let (qty, commodity) = AmountParser.parse(row.amount)
+                let com = commodity.isEmpty ? appState.config.defaultCommodity : commodity
                 postings.append(Posting(
                     account: row.account,
-                    amounts: [Amount(commodity: commodity, quantity: qty)]
+                    amounts: [Amount(commodity: com, quantity: qty)]
                 ))
             }
         }

--- a/hledger-macos/Views/Recurring/RecurringView.swift
+++ b/hledger-macos/Views/Recurring/RecurringView.swift
@@ -83,6 +83,7 @@ struct RecurringView: View {
             ) { newRule in
                 Task { await saveRule(newRule) }
             }
+            .environment(appState)
         }
         .alert("Delete Recurring Rule?", isPresented: $showingDeleteConfirm) {
             Button("Cancel", role: .cancel) {}
@@ -111,6 +112,8 @@ struct RecurringView: View {
         List(rules, selection: $selectedRule) { rule in
             RecurringRuleRow(rule: rule)
                 .tag(rule)
+                .contentShape(Rectangle())
+                .onTapGesture(count: 2) { editRule(rule) }
                 .contextMenu {
                     Button("Edit") { editRule(rule) }
                     Divider()


### PR DESCRIPTION
## Summary
- Apply default commodity when amount is entered without currency symbol, matching TransactionFormView behavior
- Add double-click to edit on recurring rule rows (was only available via context menu and Cmd+E)
- Pass AppState environment to RecurringFormView sheet

## Test plan
- [x] Create a new recurring rule entering amount without currency (e.g. "36,50") — should save with default commodity
- [x] Double-click a recurring rule row — should open edit form
- [x] Verify existing rules with explicit currency still display correctly