### PR TITLE
fix: budget duplicate entries and missing column headers

### DIFF
--- a/hledger-macos/Backend/HledgerBackend.swift
+++ b/hledger-macos/Backend/HledgerBackend.swift
@@ -295,7 +295,7 @@ final class HledgerBackend: AccountingBackend, @unchecked Sendable {
 
     func loadBudgetReport(period: String) async throws -> [BudgetRow] {
         let output = try await runHledger(
-            "balance", "--budget", "-p", period, "-O", "csv", "--no-total", "Expenses"
+            "balance", "--budget", "--flat", "-p", period, "-O", "csv", "--no-total", "Expenses"
         )
         return Self.parseCSVBudgetReport(output)
     }

--- a/hledger-macos/Views/Budget/BudgetView.swift
+++ b/hledger-macos/Views/Budget/BudgetView.swift
@@ -136,14 +136,19 @@ struct BudgetView: View {
     // MARK: - Budget List
 
     private var budgetList: some View {
-        List(mergedRows, selection: $selectedRow) { row in
-            BudgetRowView(row: row)
-                .tag(row)
-                .contextMenu {
-                    Button("Edit") { editRule(row.rule) }
-                    Divider()
-                    Button("Delete", role: .destructive) { confirmDelete(row.rule) }
-                }
+        List(selection: $selectedRow) {
+            BudgetHeaderRow()
+                .listRowSeparator(.hidden)
+
+            ForEach(mergedRows) { row in
+                BudgetRowView(row: row)
+                    .tag(row)
+                    .contextMenu {
+                        Button("Edit") { editRule(row.rule) }
+                        Divider()
+                        Button("Delete", role: .destructive) { confirmDelete(row.rule) }
+                    }
+            }
         }
         .listStyle(.inset)
         .focused($listFocused)
@@ -275,6 +280,28 @@ struct MergedBudgetRow: Identifiable, Hashable {
     var usagePct: Double {
         guard budget != 0 else { return 0 }
         return NSDecimalNumber(decimal: actual / budget * 100).doubleValue
+    }
+}
+
+// MARK: - Budget Header Row
+
+struct BudgetHeaderRow: View {
+    var body: some View {
+        HStack(spacing: 0) {
+            Text("Account")
+                .frame(width: 200, alignment: .leading)
+            Text("Budget")
+                .frame(maxWidth: .infinity, alignment: .trailing)
+            Text("Actual")
+                .frame(maxWidth: .infinity, alignment: .trailing)
+            Text("Remaining")
+                .frame(maxWidth: .infinity, alignment: .trailing)
+            Text("Usage")
+                .frame(width: 60, alignment: .trailing)
+        }
+        .font(.caption.weight(.medium))
+        .foregroundStyle(.secondary)
+        .padding(.vertical, ListMetrics.rowPadding)
     }
 }
 


### PR DESCRIPTION
## Summary
- Add `--flat` to hledger budget command to prevent tree aggregation causing duplicate rows
- Add header row (Account, Budget, Actual, Remaining, Usage) to budget list

Closes #31

## Test plan
- [x] Open Budget — no duplicate account entries
- [x] Column headers visible above first row
- [x] Budget rule for parent account with sub-account transactions shows as single row