### PR TITLE
fix: add ~/.local/bin to PATH for hledger detection

### DIFF
--- a/hledger-macos/Backend/BinaryDetector.swift
+++ b/hledger-macos/Backend/BinaryDetector.swift
@@ -18,11 +18,7 @@ enum BinaryDetector {
             "/opt/homebrew/bin/hledger",          // Apple Silicon Homebrew
             "/usr/local/bin/hledger",             // Intel Homebrew
             "/usr/bin/hledger",                   // System
-            "\(home)/.local/bin/hledger",         // stack install
-            "\(home)/.ghcup/bin/hledger",         // ghcup
-            "\(home)/.cabal/bin/hledger",         // cabal install
-            "/nix/var/nix/profiles/default/bin/hledger",  // Nix system
-            "\(home)/.nix-profile/bin/hledger",   // Nix user
+            "\(home)/.local/bin/hledger",         // stack / pipx / manual install
         ]
     }
 

--- a/hledger-macos/Backend/SubprocessRunner.swift
+++ b/hledger-macos/Backend/SubprocessRunner.swift
@@ -38,7 +38,14 @@ actor SubprocessRunner {
         process.arguments = arguments
 
         var env = ProcessInfo.processInfo.environment
-        let extraPaths = ["/opt/homebrew/bin", "/usr/local/bin", "/usr/bin", "/bin"]
+        let home = FileManager.default.homeDirectoryForCurrentUser.path
+        let extraPaths = [
+            "\(home)/.local/bin",
+            "/opt/homebrew/bin",
+            "/usr/local/bin",
+            "/usr/bin",
+            "/bin",
+        ]
         let currentPath = env["PATH"] ?? "/usr/bin:/bin"
         let allPaths = extraPaths + currentPath.split(separator: ":").map(String.init)
         env["PATH"] = allPaths.joined(separator: ":")


### PR DESCRIPTION
## Summary
- Add `~/.local/bin` to SubprocessRunner PATH (was missing, causing hledger not found from GUI)
- Simplify BinaryDetector known paths — removed ghcup/cabal/nix specific paths (covered by shell PATH fallback)

Closes #39

## Test plan
- [x] App launched from Finder detects hledger at `~/.local/bin/hledger`
- [x] Homebrew hledger still detected at `/opt/homebrew/bin/hledger`