### PR TITLE
fix: remove double-click gesture to fix selection lag

### DIFF
--- a/hledger-macos/Localizable.xcstrings
+++ b/hledger-macos/Localizable.xcstrings
@@ -26,12 +26,6 @@
         }
       }
     },
-    "%lld commands" : {
-
-    },
-    "%lld errors" : {
-
-    },
     "© 2026 Michele Broggi" : {
 
     },
@@ -71,10 +65,16 @@
     "Accepts .journal / .hledger / .j files, or a directory containing one." : {
 
     },
+    "Account" : {
+
+    },
     "Accounts" : {
 
     },
     "Accounts view" : {
+
+    },
+    "Actual" : {
 
     },
     "Add budget rules to track spending against targets." : {
@@ -112,6 +112,9 @@
 
     },
     "Asset" : {
+
+    },
+    "Bar charts" : {
 
     },
     "Book Value" : {
@@ -198,13 +201,13 @@
     "Detected: %@" : {
 
     },
-    "Display" : {
-
-    },
     "Done" : {
 
     },
     "Download" : {
+
+    },
+    "Dynamic" : {
 
     },
     "e.g. 500.00" : {
@@ -241,6 +244,9 @@
 
     },
     "Find tickers at finance.yahoo.com" : {
+
+    },
+    "Fixed width" : {
 
     },
     "Flat" : {
@@ -300,6 +306,9 @@
     "Keyboard Shortcuts" : {
 
     },
+    "Last month" : {
+
+    },
     "Later" : {
 
     },
@@ -346,6 +355,9 @@
 
     },
     "New..." : {
+
+    },
+    "No %@ to show." : {
 
     },
     "No Accounts" : {
@@ -450,6 +462,9 @@
     "Reload" : {
 
     },
+    "Remaining" : {
+
+    },
     "Remove budget for %@?" : {
 
     },
@@ -466,7 +481,7 @@
     "Reports" : {
 
     },
-    "Required for market values. Install: pip install pricehist" : {
+    "Required for market values. Install: pipx install pricehist (or pip install pricehist)" : {
 
     },
     "Save" : {
@@ -505,6 +520,9 @@
     "The journal file path has changed. All data will be reloaded from the new file." : {
 
     },
+    "Theme" : {
+
+    },
     "Ticker" : {
 
     },
@@ -524,6 +542,9 @@
 
     },
     "Update Available" : {
+
+    },
+    "Usage" : {
 
     },
     "USD" : {

--- a/hledger-macos/Views/Recurring/RecurringView.swift
+++ b/hledger-macos/Views/Recurring/RecurringView.swift
@@ -112,9 +112,6 @@ struct RecurringView: View {
         List(rules, selection: $selectedRule) { rule in
             RecurringRuleRow(rule: rule)
                 .tag(rule)
-                .contentShape(Rectangle())
-                .onTapGesture(count: 2) { editRule(rule) }
-                .onTapGesture(count: 1) { selectedRule = rule }
                 .contextMenu {
                     Button("Edit") { editRule(rule) }
                     Divider()

--- a/hledger-macos/Views/Transactions/TransactionsView.swift
+++ b/hledger-macos/Views/Transactions/TransactionsView.swift
@@ -201,9 +201,6 @@ struct TransactionsView: View {
     private func transactionRow(_ transaction: Transaction) -> some View {
         TransactionRowView(transaction: transaction)
             .tag(transaction)
-            .contentShape(Rectangle())
-            .onTapGesture(count: 2) { editTransaction(transaction) }
-            .onTapGesture(count: 1) { selectedTransaction = transaction }
             .contextMenu {
                 Button("Edit") { editTransaction(transaction) }
                 Button("Clone") { cloneTransaction(transaction) }


### PR DESCRIPTION
## Summary
- Removed `.onTapGesture(count: 2)` and `.contentShape(Rectangle())` from Transactions and Recurring lists
- SwiftUI's double-click gesture caused ~250ms delay on single clicks, making selection unresponsive
- Edit via Cmd+E or right-click > Edit (standard macOS patterns)

Closes #40

## Test plan
- [x] Single-click a transaction row — selection should appear instantly
- [x] Cmd+E opens edit form for selected transaction
- [x] Right-click > Edit works