### PR TITLE
fix: parse negative amounts with left-side currency (-€50.00)

### DIFF
--- a/hledger-macos.xcodeproj/project.pbxproj
+++ b/hledger-macos.xcodeproj/project.pbxproj
@@ -480,7 +480,7 @@
 				SWIFT_EMIT_LOC_STRINGS = NO;
 				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
 				SWIFT_VERSION = 5.0;
-				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/hledger-macos.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/hledger-macos";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/hledger for Mac.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/hledger for Mac";
 			};
 			name = Debug;
 		};
@@ -503,7 +503,7 @@
 				SWIFT_EMIT_LOC_STRINGS = NO;
 				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
 				SWIFT_VERSION = 5.0;
-				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/hledger-macos.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/hledger-macos";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/hledger for Mac.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/hledger for Mac";
 			};
 			name = Release;
 		};

--- a/hledger-macos.xcodeproj/xcshareddata/xcschemes/hledger-macos.xcscheme
+++ b/hledger-macos.xcodeproj/xcshareddata/xcschemes/hledger-macos.xcscheme
@@ -1,0 +1,99 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1640"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "920DA2362F7A47800060ED7A"
+               BuildableName = "hledger for Mac.app"
+               BlueprintName = "hledger-macos"
+               ReferencedContainer = "container:hledger-macos.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "NO">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "920DA2452F7A47800060ED7A"
+               BuildableName = "hledger-macosTests.xctest"
+               BlueprintName = "hledger-macosTests"
+               ReferencedContainer = "container:hledger-macos.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "920DA24F2F7A47800060ED7A"
+               BuildableName = "hledger-macosUITests.xctest"
+               BlueprintName = "hledger-macosUITests"
+               ReferencedContainer = "container:hledger-macos.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "920DA2362F7A47800060ED7A"
+            BuildableName = "hledger for Mac.app"
+            BlueprintName = "hledger-macos"
+            ReferencedContainer = "container:hledger-macos.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "920DA2362F7A47800060ED7A"
+            BuildableName = "hledger for Mac.app"
+            BlueprintName = "hledger-macos"
+            ReferencedContainer = "container:hledger-macos.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/hledger-macos/Config/AmountParser.swift
+++ b/hledger-macos/Config/AmountParser.swift
@@ -9,14 +9,15 @@ enum AmountParser {
         let trimmed = s.trimmingCharacters(in: .whitespaces)
         guard !trimmed.isEmpty, trimmed != "0" else { return (0, "") }
 
-        // Left-side commodity: €500.00 or €500,00
-        if let match = trimmed.firstMatch(of: /^([^\d\s.\-]+)\s*(-?[\d.,]+)$/) {
-            let commodity = String(match.1)
-            let qty = parseNumber(String(match.2))
+        // Left-side commodity: €500.00, €-500.00, -€500.00
+        if let match = trimmed.firstMatch(of: /^(-?)([^\d\s.\-]+)\s*(-?[\d.,]+)$/) {
+            let sign = String(match.1)
+            let commodity = String(match.2)
+            let qty = parseNumber(sign + String(match.3))
             return (qty, commodity)
         }
 
-        // Right-side commodity: 500.00 EUR or 500,00 EUR
+        // Right-side commodity: 500.00 EUR, -500.00 EUR
         if let match = trimmed.firstMatch(of: /^(-?[\d.,]+)\s*([^\d\s.\-]+)$/) {
             let qty = parseNumber(String(match.1))
             let commodity = String(match.2)

--- a/hledger-macosTests/hledger_macosTests.swift
+++ b/hledger-macosTests/hledger_macosTests.swift
@@ -1,6 +1,6 @@
 import Testing
 import Foundation
-@testable import hledger_macos
+@testable import hledger_for_Mac
 
 // MARK: - AmountParser Tests
 
@@ -80,6 +80,68 @@ struct AmountParserTests {
         let (qty, com) = AmountParser.parse("€-174420.00")
         #expect(qty == Decimal(string: "-174420.00"))
         #expect(com == "€")
+    }
+
+    // Roundtrip: Amount.formatted() -> AmountParser.parse()
+    // These test the exact strings that Amount.formatted() produces
+    // for negative amounts, which must survive re-parsing.
+
+    @Test func negativeSignBeforeCurrency() {
+        // Amount.formatted() produces "-€50.00" for negative left-side commodity
+        let (qty, com) = AmountParser.parse("-€50.00")
+        #expect(qty == Decimal(string: "-50.00"))
+        #expect(com == "€")
+    }
+
+    @Test func negativeSignBeforeDollar() {
+        let (qty, com) = AmountParser.parse("-$1000.00")
+        #expect(qty == Decimal(string: "-1000.00"))
+        #expect(com == "$")
+    }
+
+    @Test func negativeSignBeforePound() {
+        let (qty, com) = AmountParser.parse("-£25.50")
+        #expect(qty == Decimal(string: "-25.50"))
+        #expect(com == "£")
+    }
+
+    @Test func negativeRightSideCommodity() {
+        // Amount.formatted() produces "-50.00 EUR" for negative right-side commodity
+        let (qty, com) = AmountParser.parse("-50.00 EUR")
+        #expect(qty == Decimal(string: "-50.00"))
+        #expect(com == "EUR")
+    }
+
+    @Test func roundtripPositiveLeftSide() {
+        let amount = Amount(commodity: "€", quantity: Decimal(string: "50.00")!, style: AmountStyle(commoditySide: .left, precision: 2))
+        let formatted = amount.formatted()
+        let (qty, com) = AmountParser.parse(formatted)
+        #expect(qty == Decimal(string: "50.00"))
+        #expect(com == "€")
+    }
+
+    @Test func roundtripNegativeLeftSide() {
+        let amount = Amount(commodity: "€", quantity: Decimal(string: "-50.00")!, style: AmountStyle(commoditySide: .left, precision: 2))
+        let formatted = amount.formatted()
+        let (qty, com) = AmountParser.parse(formatted)
+        #expect(qty == Decimal(string: "-50.00"))
+        #expect(com == "€")
+    }
+
+    @Test func roundtripPositiveRightSide() {
+        let amount = Amount(commodity: "EUR", quantity: Decimal(string: "1234.56")!, style: AmountStyle(commoditySide: .right, precision: 2))
+        let formatted = amount.formatted()
+        let (qty, com) = AmountParser.parse(formatted)
+        #expect(qty == Decimal(string: "1234.56"))
+        #expect(com == "EUR")
+    }
+
+    @Test func roundtripNegativeRightSide() {
+        let amount = Amount(commodity: "EUR", quantity: Decimal(string: "-1234.56")!, style: AmountStyle(commoditySide: .right, precision: 2))
+        let formatted = amount.formatted()
+        let (qty, com) = AmountParser.parse(formatted)
+        #expect(qty == Decimal(string: "-1234.56"))
+        #expect(com == "EUR")
     }
 }
 


### PR DESCRIPTION
## Summary
- `AmountParser` failed to parse `-€50.00` (sign before commodity), causing posting amounts to be lost on edit
- Updated regex to capture optional leading sign
- Added 8 roundtrip tests (Amount.formatted() -> AmountParser.parse())
- Fixed TEST_HOST and module import for unit tests on main
- Added shared xcscheme with test target

Closes #41

## Test plan
- [x] Edit a transaction with negative amounts (e.g. Assets:Bank -€50.00) — amounts should be preserved after save
- [x] All 59 unit tests pass