### PR TITLE
fix: replace popover autocomplete with textInputSuggestions

### DIFF
--- a/hledger-macos/Views/Shared/AutocompleteField.swift
+++ b/hledger-macos/Views/Shared/AutocompleteField.swift
@@ -1,4 +1,5 @@
-/// Text field with popover autocomplete suggestions.
+/// Text field with native SwiftUI autocomplete suggestions.
+/// Uses .textInputSuggestions for proper macOS integration without focus issues.
 
 import SwiftUI
 
@@ -7,98 +8,32 @@ struct AutocompleteField: View {
     @Binding var text: String
     let suggestions: [String]
 
-    @State private var showSuggestions = false
-    @State private var selectedIndex = 0
-    @State private var justAccepted = false
-    @FocusState private var isFocused: Bool
+    @State private var debouncedText = ""
+    @State private var debounceTask: Task<Void, Never>?
 
     private var filtered: [String] {
-        guard !text.isEmpty else { return [] }
-        let query = text.lowercased()
+        guard !debouncedText.isEmpty else { return [] }
+        let query = debouncedText.lowercased()
         return suggestions.filter { $0.lowercased().contains(query) && $0 != text }.prefix(8).map { $0 }
     }
 
     var body: some View {
         TextField(placeholder, text: $text)
             .textFieldStyle(.roundedBorder)
-            .focused($isFocused)
             .onChange(of: text) {
-                if justAccepted {
-                    justAccepted = false
-                    return
-                }
-                selectedIndex = 0
-                showSuggestions = isFocused && !filtered.isEmpty
-            }
-            .onChange(of: isFocused) {
-                if !isFocused {
-                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.15) {
-                        showSuggestions = false
+                debounceTask?.cancel()
+                debounceTask = Task {
+                    try? await Task.sleep(for: .milliseconds(300))
+                    if !Task.isCancelled {
+                        debouncedText = text
                     }
                 }
             }
-            .onSubmit {
-                if showSuggestions && !filtered.isEmpty {
-                    acceptSuggestion(filtered[selectedIndex])
+            .textInputSuggestions {
+                ForEach(filtered, id: \.self) { suggestion in
+                    Text(suggestion)
+                        .textInputCompletion(suggestion)
                 }
-                showSuggestions = false
             }
-            .onKeyPress(.tab) {
-                if showSuggestions && !filtered.isEmpty {
-                    acceptSuggestion(filtered[selectedIndex])
-                }
-                return .ignored
-            }
-            .onKeyPress(.downArrow) {
-                if showSuggestions && selectedIndex < filtered.count - 1 {
-                    selectedIndex += 1
-                    return .handled
-                }
-                return .ignored
-            }
-            .onKeyPress(.upArrow) {
-                if showSuggestions && selectedIndex > 0 {
-                    selectedIndex -= 1
-                    return .handled
-                }
-                return .ignored
-            }
-            .onKeyPress(.escape) {
-                if showSuggestions {
-                    showSuggestions = false
-                    return .handled
-                }
-                return .ignored
-            }
-            .popover(isPresented: $showSuggestions, arrowEdge: .bottom) {
-                VStack(alignment: .leading, spacing: 0) {
-                    ForEach(Array(filtered.enumerated()), id: \.element) { index, suggestion in
-                        Button {
-                            acceptSuggestion(suggestion)
-                        } label: {
-                            Text(suggestion)
-                                .font(.callout)
-                                .frame(maxWidth: .infinity, alignment: .leading)
-                                .padding(.horizontal, 10)
-                                .padding(.vertical, 5)
-                                .contentShape(Rectangle())
-                                .background(index == selectedIndex ? Color.accentColor.opacity(0.2) : Color.clear)
-                        }
-                        .buttonStyle(.plain)
-
-                        if index < filtered.count - 1 {
-                            Divider()
-                        }
-                    }
-                }
-                .frame(width: 280)
-                .padding(.vertical, 4)
-            }
-    }
-
-    private func acceptSuggestion(_ suggestion: String) {
-        justAccepted = true
-        text = suggestion
-        showSuggestions = false
     }
 }


### PR DESCRIPTION
## Summary
- SwiftUI's `.popover` was stealing focus from TextField on macOS, causing each keystroke to replace text instead of appending
- Replaced with native `.textInputSuggestions` API with 300ms debounce
- From 80 lines of custom code to 15 lines with the native API

Closes #37

## Test plan
- [x] Type in Description field — text accumulates normally, suggestions appear after 300ms
- [x] Type in Account fields (postings) — same behavior
- [x] Works in Transactions, Recurring, and Budget forms