### PR TITLE
fix: re-add ~/.cabal/bin to hledger detection paths

### DIFF
--- a/hledger-macos/Backend/BinaryDetector.swift
+++ b/hledger-macos/Backend/BinaryDetector.swift
@@ -16,9 +16,10 @@ enum BinaryDetector {
         let home = FileManager.default.homeDirectoryForCurrentUser.path
         return [
             "/opt/homebrew/bin/hledger",          // Apple Silicon Homebrew
-            "/usr/local/bin/hledger",             // Intel Homebrew
+            "/usr/local/bin/hledger",             // Intel Homebrew / generic
             "/usr/bin/hledger",                   // System
-            "\(home)/.local/bin/hledger",         // stack / pipx / manual install
+            "\(home)/.local/bin/hledger",         // stack
+            "\(home)/.cabal/bin/hledger",         // cabal
         ]
     }
 


### PR DESCRIPTION
## Summary
Per feedback from hledger maintainer (@simonmichael) in #39, re-add `~/.cabal/bin` to known detection paths. It was removed prematurely in PR #45.

Detection paths:
- `/opt/homebrew/bin` — Homebrew ARM
- `/usr/local/bin` — Homebrew Intel / generic
- `~/.local/bin` — stack
- `~/.cabal/bin` — cabal (re-added)

GHCup (`~/.ghcup/bin`) confirmed NOT needed for hledger.