### PR TITLE
ci: force Node.js 24 for GitHub Actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,9 @@ on:
 permissions:
   contents: write
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   build:
     runs-on: macos-26


### PR DESCRIPTION
Add FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true env var to suppress Node.js 20 deprecation warning from softprops/action-gh-release@v2 (v3 does not exist).