### PR TITLE
chore: bump version to 0.1.1

### DIFF
--- a/hledger-macos.xcodeproj/project.pbxproj
+++ b/hledger-macos.xcodeproj/project.pbxproj
@@ -414,7 +414,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 0.1.0;
+				MARKETING_VERSION = 0.1.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.thesmokinator.hledger-macos";
 				PRODUCT_NAME = "hledger for Mac";
 				REGISTER_APP_GROUPS = YES;
@@ -448,7 +448,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 0.1.0;
+				MARKETING_VERSION = 0.1.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.thesmokinator.hledger-macos";
 				PRODUCT_NAME = "hledger for Mac";
 				REGISTER_APP_GROUPS = YES;


### PR DESCRIPTION
## Summary

- Bump `MARKETING_VERSION` from 0.1.0 to 0.1.1 in preparation for release

## Context

Version bump for the commodity style fix (#56, #60). Tag `v0.1.1` will be created after merge.