### PR TITLE
feat: auto-detect commodities from journal for settings picker

### DIFF
--- a/hledger-macos/Config/AppConfig.swift
+++ b/hledger-macos/Config/AppConfig.swift
@@ -22,6 +22,12 @@ final class AppConfig {
         set { UserDefaults.standard.set(newValue, forKey: "defaultCommodity") }
     }
 
+    /// Whether the user has explicitly chosen a commodity in Settings.
+    var hasUserSetCommodity: Bool {
+        get { UserDefaults.standard.object(forKey: "hasUserSetCommodity") as? Bool ?? false }
+        set { UserDefaults.standard.set(newValue, forKey: "hasUserSetCommodity") }
+    }
+
     /// Accounts view mode (flat or tree).
     var accountsViewMode: String {
         get { UserDefaults.standard.string(forKey: "accountsViewMode") ?? "flat" }

--- a/hledger-macos/Services/AppState.swift
+++ b/hledger-macos/Services/AppState.swift
@@ -335,8 +335,17 @@ final class AppState {
         await loadTransactions()
         await loadAccounts()
         await loadStats()
+        autoDetectCommodityIfNeeded()
         await loadSummary()
         dataVersion = UUID()
+    }
+
+    /// Auto-set the default commodity if the journal has exactly one and the user hasn't chosen.
+    private func autoDetectCommodityIfNeeded() {
+        guard !config.hasUserSetCommodity,
+              let commodities = journalStats?.commodities,
+              commodities.count == 1 else { return }
+        config.defaultCommodity = commodities[0]
     }
 
     /// Navigate to previous month.

--- a/hledger-macos/Views/Settings/SettingsView.swift
+++ b/hledger-macos/Views/Settings/SettingsView.swift
@@ -69,17 +69,16 @@ struct SettingsView: View {
                     }
 
                     Picker("Default commodity", selection: $commodity) {
-                        Text("€").tag("€")
-                        Text("$").tag("$")
-                        Text("£").tag("£")
-                        Text("EUR").tag("EUR")
-                        Text("USD").tag("USD")
-                        Text("GBP").tag("GBP")
-                        Divider()
+                        if let commodities = appState.journalStats?.commodities, !commodities.isEmpty {
+                            ForEach(commodities, id: \.self) { c in
+                                Text(c).tag(c)
+                            }
+                            Divider()
+                        }
                         Text("Custom...").tag("__custom__")
                     }
 
-                    if commodity == "__custom__" || !["€", "$", "£", "EUR", "USD", "GBP"].contains(commodity) {
+                    if commodity == "__custom__" || !(appState.journalStats?.commodities ?? []).contains(commodity) {
                         TextField("", text: $customCommodity, prompt: Text("CHF, SEK, BTC..."))
                             .multilineTextAlignment(.trailing)
                             .onSubmit { commodity = customCommodity }
@@ -362,7 +361,8 @@ struct SettingsView: View {
         journalPath = appState.config.journalFilePath
         originalJournalPath = journalPath
         let savedCommodity = appState.config.defaultCommodity
-        if ["€", "$", "£", "EUR", "USD", "GBP"].contains(savedCommodity) {
+        let knownCommodities = appState.journalStats?.commodities ?? []
+        if knownCommodities.contains(savedCommodity) {
             commodity = savedCommodity
         } else {
             commodity = savedCommodity
@@ -401,6 +401,7 @@ struct SettingsView: View {
     private func performSave() {
         appState.config.journalFilePath = journalPath
         appState.config.defaultCommodity = commodity
+        appState.config.hasUserSetCommodity = true
         appState.config.accountsViewMode = accountsView
         appState.config.accountsTreeExpanded = treeExpanded
         appState.config.hledgerBinaryPath = hledgerPath


### PR DESCRIPTION
## Summary

- Replace hardcoded commodity list (€, $, £, EUR, USD, GBP) in Settings picker with dynamic list from `hledger commodities`
- Auto-select the default commodity if the journal has exactly one (no user action needed)
- Track explicit user choice with `hasUserSetCommodity` flag to avoid overwriting it on reload

Fixes #58

## What changed

| File | Change |
|---|---|
| `Config/AppConfig.swift` | Add `hasUserSetCommodity` UserDefaults flag |
| `Services/AppState.swift` | `autoDetectCommodityIfNeeded()` after `loadStats()` in `reload()` |
| `Views/Settings/SettingsView.swift` | Dynamic picker from `journalStats.commodities`, set flag on save |

## Test plan

- [x] Build succeeds
- [x] Settings picker shows journal commodities dynamically
- [x] Single-commodity journal auto-selects on first launch
- [x] "Custom..." option still works for new commodities
- [x] Explicit user choice is preserved across reloads