### PR TITLE
chore: bump version to 0.1.3

### DIFF
--- a/hledger-macos.xcodeproj/project.pbxproj
+++ b/hledger-macos.xcodeproj/project.pbxproj
@@ -414,7 +414,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 0.1.2;
+				MARKETING_VERSION = 0.1.3;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.thesmokinator.hledger-macos";
 				PRODUCT_NAME = "hledger for Mac";
 				REGISTER_APP_GROUPS = YES;
@@ -448,7 +448,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 0.1.2;
+				MARKETING_VERSION = 0.1.3;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.thesmokinator.hledger-macos";
 				PRODUCT_NAME = "hledger for Mac";
 				REGISTER_APP_GROUPS = YES;


### PR DESCRIPTION
## Summary
- Bump `MARKETING_VERSION` to 0.1.3 (Debug + Release)

## What's in this release
- feat: account drill-down sheet with period filter (#65, PR #66)
- fix: `expandSearchQuery` corrupting `acct:`/`amt:` queries when `tag:` alias applied (#67, PR #66)
- fix: resolve journal path via `hledger files` in login shell — fixes no-data on GUI launch (#39, PR #68)

## Test plan
- [x] Merge and tag `v0.1.3` to trigger CI release