### PR TITLE
fix: use date range for price fetching to handle weekends and holidays

### DIFF
--- a/hledger-macos/Services/AppState.swift
+++ b/hledger-macos/Services/AppState.swift
@@ -68,6 +68,8 @@ final class AppState {
     var assets: [(String, Decimal, String)] = []
     var portfolio: [PortfolioRow] = []
     var isFetchingPrices = false
+    /// Ticker symbols for which no price data could be fetched (e.g. unknown symbol, network error).
+    var failedPriceTickers: Set<String> = []
     var multiCurrencyAccounts: Set<String> = []
 
     // MARK: - UI State
@@ -298,7 +300,9 @@ final class AppState {
         guard !tickers.isEmpty else { return }
 
         isFetchingPrices = true
-        if let pricesFile = await PriceService.getPricesFile(pricehistPath: config.pricehistBinaryPath, tickers: tickers) {
+        let (pricesFile, failed) = await PriceService.getPricesFile(pricehistPath: config.pricehistBinaryPath, tickers: tickers)
+        failedPriceTickers = failed
+        if let pricesFile {
             do {
                 let marketValues = try await backend.loadInvestmentMarketValues(pricesFile: pricesFile)
                 let positions = try await backend.loadInvestmentPositions()

--- a/hledger-macos/Services/PriceFetcher.swift
+++ b/hledger-macos/Services/PriceFetcher.swift
@@ -1,0 +1,72 @@
+/// Helper for fetching the most recent available market price via pricehist.
+///
+/// Instead of querying a single date (which fails on weekends/holidays), fetches
+/// a lookback window and extracts the most recent trading day's price directive.
+
+import Foundation
+
+enum PriceFetcher {
+    /// Parse the most recent P-directive from pricehist ledger output.
+    ///
+    /// pricehist may return multiple lines (one per trading day in the range).
+    /// This function returns only the last non-empty line, cleaned for hledger.
+    static func parseLatestDirective(from output: String) -> String? {
+        output.split(separator: "\n")
+            .map { $0.trimmingCharacters(in: .whitespaces) }
+            .filter { !$0.isEmpty }
+            .last
+            .map(cleanPDirective)
+    }
+
+    /// Fetch the most recent trading day price for a ticker within the last `lookbackDays` days.
+    ///
+    /// Uses a date range instead of a single date so that weekends and public holidays
+    /// are handled transparently — pricehist returns all available trading days in the
+    /// range and we take the latest one.
+    ///
+    /// - Parameters:
+    ///   - runner: Configured `SubprocessRunner` pointing to the pricehist binary.
+    ///   - ticker: Yahoo Finance ticker symbol (e.g. "XEON.MI").
+    ///   - commodity: hledger commodity name to use in the P-directive (e.g. "XEON").
+    ///   - lookbackDays: How many calendar days back to search. Defaults to 7,
+    ///     which covers weekends and most national holiday gaps.
+    /// - Returns: A cleaned hledger P-directive string, or `nil` if no data was found.
+    static func fetchLatestPrice(
+        runner: SubprocessRunner,
+        ticker: String,
+        commodity: String,
+        lookbackDays: Int = 7
+    ) async throws -> String? {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd"
+        let end = formatter.string(from: .now)
+        let startDate = Calendar.current.date(byAdding: .day, value: -lookbackDays, to: .now)!
+        let start = formatter.string(from: startDate)
+
+        let output = try await runner.run([
+            "fetch", "yahoo", ticker,
+            "-s", start, "-e", end,
+            "-o", "ledger",
+            "--fmt-base", commodity
+        ])
+
+        return parseLatestDirective(from: output)
+    }
+
+    /// Clean a single pricehist P-directive for hledger compatibility.
+    ///
+    /// pricehist outputs: `P 2026-04-02 00:00:00 SWDA 112.73999786 EUR`
+    /// hledger expects:   `P 2026-04-02 SWDA 112.74 EUR`
+    static func cleanPDirective(_ line: String) -> String {
+        var parts = line.split(separator: " ", omittingEmptySubsequences: true).map(String.init)
+        // Remove timestamp (HH:MM:SS) after the date if present
+        if parts.count >= 3 && parts[2].contains(":") {
+            parts.remove(at: 2)
+        }
+        // Round price to 2 decimal places
+        if parts.count >= 4, let price = Double(parts[3]) {
+            parts[3] = String(format: "%.2f", price)
+        }
+        return parts.joined(separator: " ")
+    }
+}

--- a/hledger-macos/Services/PriceService.swift
+++ b/hledger-macos/Services/PriceService.swift
@@ -44,69 +44,47 @@ enum PriceService {
         !path.isEmpty && FileManager.default.isExecutableFile(atPath: path)
     }
 
-    /// Clean pricehist output: remove timestamps and limit decimal precision.
-    private static func cleanPDirective(_ line: String) -> String {
-        // pricehist outputs: P 2026-04-02 00:00:00 SWDA 112.73999786 EUR
-        // hledger expects:  P 2026-04-02 SWDA 112.74 EUR
-        var parts = line.split(separator: " ", omittingEmptySubsequences: true).map(String.init)
-        // Remove timestamp (HH:MM:SS) if present after date
-        if parts.count >= 3 && parts[2].contains(":") {
-            parts.remove(at: 2)
-        }
-        // Round price to 2 decimals if it's a number
-        if parts.count >= 4, let price = Double(parts[3]) {
-            parts[3] = String(format: "%.2f", price)
-        }
-        return parts.joined(separator: " ")
-    }
-
     /// Get the prices file URL: return cache if fresh, fetch if stale.
-    /// Returns nil if pricehist path is not configured/valid or no tickers configured.
-    static func getPricesFile(pricehistPath: String, tickers: [String: String]) async -> URL? {
-        guard !tickers.isEmpty else { return nil }
-        guard isValid(path: pricehistPath) else { return nil }
+    ///
+    /// Returns `nil` for the URL if pricehist is not configured, no tickers are set,
+    /// or all fetches failed. The second element of the tuple contains any ticker
+    /// symbols for which no price data could be retrieved.
+    static func getPricesFile(
+        pricehistPath: String,
+        tickers: [String: String]
+    ) async -> (URL?, Set<String>) {
+        guard !tickers.isEmpty else { return (nil, []) }
+        guard isValid(path: pricehistPath) else { return (nil, []) }
 
         if pricesAreFresh(tickers: tickers) {
-            return cachePath
+            return (cachePath, [])
         }
 
         let runner = SubprocessRunner(executablePath: pricehistPath)
-        let today = {
-            let f = DateFormatter()
-            f.dateFormat = "yyyy-MM-dd"
-            return f.string(from: Date())
-        }()
-
         var lines: [String] = []
+        var failed: Set<String> = []
 
         for (commodity, ticker) in tickers {
             do {
-                let output = try await runner.run([
-                    "fetch", "yahoo", ticker,
-                    "-s", today, "-e", today,
-                    "-o", "ledger",
-                    "--fmt-base", commodity
-                ])
-                for line in output.split(separator: "\n") {
-                    let trimmed = line.trimmingCharacters(in: .whitespaces)
-                    if !trimmed.isEmpty {
-                        lines.append(cleanPDirective(trimmed))
-                    }
+                if let directive = try await PriceFetcher.fetchLatestPrice(runner: runner, ticker: ticker, commodity: commodity) {
+                    lines.append(directive)
+                } else {
+                    failed.insert(ticker)
                 }
             } catch {
-                continue
+                failed.insert(ticker)
             }
         }
 
-        guard !lines.isEmpty else { return nil }
+        guard !lines.isEmpty else { return (nil, failed) }
 
         do {
             let content = lines.joined(separator: "\n") + "\n"
             try content.write(to: cachePath, atomically: true, encoding: .utf8)
             try tickerHash(for: tickers).write(to: tickerHashPath, atomically: true, encoding: .utf8)
-            return cachePath
+            return (cachePath, failed)
         } catch {
-            return nil
+            return (nil, failed)
         }
     }
 }

--- a/hledger-macos/Views/MainWindow/SummaryView.swift
+++ b/hledger-macos/Views/MainWindow/SummaryView.swift
@@ -193,6 +193,14 @@ struct SummaryView: View {
                     .font(.caption)
                     .foregroundStyle(.tertiary)
                     .padding(.top, 4)
+            } else if !appState.failedPriceTickers.isEmpty {
+                Label(
+                    "Could not fetch prices for: \(appState.failedPriceTickers.sorted().joined(separator: ", "))",
+                    systemImage: "exclamationmark.triangle"
+                )
+                .font(.caption)
+                .foregroundStyle(.orange)
+                .padding(.top, 4)
             } else if showMarketColumns {
                 Text("Market data provided by pricehist via Yahoo Finance. Prices may be delayed.")
                     .font(.caption2)

--- a/hledger-macosTests/hledger_macosTests.swift
+++ b/hledger-macosTests/hledger_macosTests.swift
@@ -1182,3 +1182,44 @@ struct IntegrationTests {
         #expect(correctValue == Decimal(string: "1000"))
     }
 }
+
+// MARK: - PriceFetcher Tests
+
+@Suite("PriceFetcher")
+struct PriceFetcherTests {
+    @Test func parsesLastLineFromMultiDayOutput() {
+        let output = """
+        P 2026-04-02 00:00:00 XEON 5.12 EUR
+        P 2026-04-03 00:00:00 XEON 5.15 EUR
+        P 2026-04-04 00:00:00 XEON 5.18 EUR
+        """
+        let result = PriceFetcher.parseLatestDirective(from: output)
+        #expect(result == "P 2026-04-04 XEON 5.18 EUR")
+    }
+
+    @Test func parsesOnlyLineWhenSingleTradingDay() {
+        let output = "P 2026-04-04 00:00:00 SWDA 112.73999786 EUR\n"
+        let result = PriceFetcher.parseLatestDirective(from: output)
+        #expect(result == "P 2026-04-04 SWDA 112.74 EUR")
+    }
+
+    @Test func returnsNilForEmptyOutput() {
+        #expect(PriceFetcher.parseLatestDirective(from: "") == nil)
+        #expect(PriceFetcher.parseLatestDirective(from: "   \n  \n") == nil)
+    }
+
+    @Test func cleansTimestamp() {
+        let result = PriceFetcher.cleanPDirective("P 2026-04-04 00:00:00 XEON 5.18345 EUR")
+        #expect(result == "P 2026-04-04 XEON 5.18 EUR")
+    }
+
+    @Test func cleansRoundsPrice() {
+        let result = PriceFetcher.cleanPDirective("P 2026-04-04 XEON 5.18999 EUR")
+        #expect(result == "P 2026-04-04 XEON 5.19 EUR")
+    }
+
+    @Test func cleansLineWithoutTimestamp() {
+        let result = PriceFetcher.cleanPDirective("P 2026-04-04 XEON 5.18 EUR")
+        #expect(result == "P 2026-04-04 XEON 5.18 EUR")
+    }
+}


### PR DESCRIPTION
Closes #69

## Summary

- Price fetching used today's date as both start and end, which fails on weekends/holidays when Yahoo Finance has no data
- Now uses a 7-day lookback window via `PriceFetcher.fetchLatestPrice()` and takes the most recent trading day's price
- Extracted price fetching logic into `PriceFetcher` for testability and separation of concerns
- `getPricesFile()` now returns failed tickers so the UI can warn the user instead of silently showing empty values
- Added warning label in `SummaryView` for tickers that failed to fetch

## Test plan

- [x] Open the app on a weekend → market prices should display correctly (using Friday's close)
- [x] Configure an invalid ticker → warning message should appear in the portfolio section
- [x] Verify price cache still works (second load should use cached values)
- [x] Run `PriceFetcherTests` — all pass