### PR TITLE
chore: bump version to 0.1.4

### DIFF
--- a/hledger-macos.xcodeproj/project.pbxproj
+++ b/hledger-macos.xcodeproj/project.pbxproj
@@ -414,7 +414,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 0.1.3;
+				MARKETING_VERSION = 0.1.4;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.thesmokinator.hledger-macos";
 				PRODUCT_NAME = "hledger for Mac";
 				REGISTER_APP_GROUPS = YES;
@@ -448,7 +448,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 0.1.3;
+				MARKETING_VERSION = 0.1.4;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.thesmokinator.hledger-macos";
 				PRODUCT_NAME = "hledger for Mac";
 				REGISTER_APP_GROUPS = YES;


### PR DESCRIPTION
## Summary

- Bump `MARKETING_VERSION` from 0.1.3 to 0.1.4

## Changes in this release

- fix: show OnboardingView when journal file is missing (#71)
- fix: use date range for price fetching to handle weekends and holidays (#69)
- fix: resolve concurrency warnings in AppState and PriceFetcher
- test: protocol injection and unit tests for detectAndSetup
- test: Xcode previews for OnboardingView scenarios