### PR TITLE
fix: improve readability of secondary text in Summary

### DIFF
--- a/hledger-macos/Views/MainWindow/SummaryView.swift
+++ b/hledger-macos/Views/MainWindow/SummaryView.swift
@@ -202,9 +202,9 @@ struct SummaryView: View {
                 .foregroundStyle(.orange)
                 .padding(.top, 4)
             } else if showMarketColumns {
-                Text("Market data provided by pricehist via Yahoo Finance. Prices may be delayed.")
-                    .font(.caption2)
-                    .foregroundStyle(.quaternary)
+                Label("Prices via Yahoo Finance (delayed)", systemImage: "info.circle")
+                    .font(.caption)
+                    .foregroundStyle(.tertiary)
                     .padding(.top, 4)
             }
         }

--- a/hledger-macos/Views/Shared/SummaryCard.swift
+++ b/hledger-macos/Views/Shared/SummaryCard.swift
@@ -41,7 +41,7 @@ struct SummaryCard: View {
 
             Text(subtitle ?? " ")
                 .font(.caption)
-                .foregroundStyle(.tertiary)
+                .foregroundStyle(.secondary)
         }
         .frame(maxWidth: .infinity, minHeight: 100)
         .padding(.vertical, 16)


### PR DESCRIPTION
Closes #76

## Summary

- Saving rate subtitle: `.tertiary` → `.secondary` for better contrast in dark mode
- Market data disclaimer: shortened to "Prices via Yahoo Finance (delayed)" with `info.circle` icon, `.quaternary` → `.tertiary`, `.caption2` → `.caption`

## Test plan

- [ ] Verify "Saving rate: XX%" is readable in both light and dark mode
- [ ] Verify "Prices via Yahoo Finance (delayed)" with info icon is visible under Investments