### PR TITLE
chore: bump version to 0.1.5

### DIFF
--- a/hledger-macos.xcodeproj/project.pbxproj
+++ b/hledger-macos.xcodeproj/project.pbxproj
@@ -414,7 +414,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 0.1.4;
+				MARKETING_VERSION = 0.1.5;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.thesmokinator.hledger-macos";
 				PRODUCT_NAME = "hledger for Mac";
 				REGISTER_APP_GROUPS = YES;
@@ -448,7 +448,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 0.1.4;
+				MARKETING_VERSION = 0.1.5;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.thesmokinator.hledger-macos";
 				PRODUCT_NAME = "hledger for Mac";
 				REGISTER_APP_GROUPS = YES;


### PR DESCRIPTION
## Summary

- Bump `MARKETING_VERSION` from 0.1.4 to 0.1.5

## Changes in this release

- feat: CSV import wizard with rules editor (#64)
- feat: row selection and account drill-down in Reports (#78)
- fix: improve readability of secondary text in Summary (#76)
- fix: align settings fields in Rules Editor
- Menu: "New Transaction" instead of "New...", Cmd+N from Summary navigates to Transactions
- Tools menu: Rules Manager
- Examples: 3 CSV + rules file pairs in `examples/csv-import/`