### PR TITLE
fix: parse cost annotations with European decimals in posting form

### DIFF
--- a/hledger-macos/Config/PostingAmountParser.swift
+++ b/hledger-macos/Config/PostingAmountParser.swift
@@ -1,0 +1,171 @@
+/// Parses posting amount strings entered by the user in transaction forms.
+///
+/// This is a higher-level parser than `AmountParser`: it returns a complete
+/// `Amount` object (including optional cost annotation) instead of a simple
+/// `(Decimal, String)` tuple. It's designed for user input in transaction
+/// forms where cost annotations like `-5 XDWD @@ €742,55` are common.
+///
+/// Supported formats:
+/// - Plain number:          `50.00`, `-50,00`
+/// - Currency prefix:       `€50.00`, `-€50,00`, `€-50.00`
+/// - Currency suffix:       `50.00 EUR`, `-50,00 EUR`
+/// - Named commodity:       `-5 XDWD`, `10 AAPL`
+/// - With total cost (@@):  `-5 XDWD @@ €742,55`
+/// - With unit cost (@):    `-5 XDWD @ €148.518` (converted to total cost)
+///
+/// Handles both US (`1,000.00`) and European (`1.000,00`) number formats.
+/// The returned `Amount` always uses `.` as decimal mark (the default), so
+/// `Amount.formatted()` produces hledger-compatible output regardless of
+/// whether the user typed `,` or `.`.
+
+import Foundation
+
+enum PostingAmountParser {
+
+    // MARK: - Regex
+
+    /// Matches a cost-annotated amount string.
+    ///
+    /// Groups: `(quantity)(commodity)(@@?)(cost)`
+    /// Examples: `-1 SWDA @@ 112,93`, `-5 XDWD @@ €742.55`, `10 AAPL @ €22.50`
+    private static let costRegex = /^(-?[\d.,]+)\s+([A-Za-z][A-Za-z0-9]*)\s+(@@?)\s+(.+)$/
+
+    // MARK: - Public API
+
+    /// Parse a posting amount string into an `Amount`.
+    ///
+    /// Tries the cost-annotated pattern first (`qty COMMODITY @@ cost`); falls
+    /// back to simple amount parsing if no cost annotation is found.
+    ///
+    /// - Parameters:
+    ///   - input: The raw user-entered amount string.
+    ///   - defaultCommodity: Commodity to use when the input has no explicit one.
+    /// - Returns: An `Amount` if parsing succeeds, `nil` otherwise.
+    static func parse(_ input: String, defaultCommodity: String = "") -> Amount? {
+        let trimmed = input.trimmingCharacters(in: .whitespaces)
+        guard !trimmed.isEmpty else { return nil }
+
+        if let amount = parseCostAnnotated(trimmed, defaultCommodity: defaultCommodity) {
+            return amount
+        }
+        return parseSimple(trimmed, defaultCommodity: defaultCommodity)
+    }
+
+    /// Parse a cost-annotated amount like `-5 XDWD @@ €742,55` or `-5 XDWD @ €148.518`.
+    ///
+    /// Returns `nil` if the input does not match the cost pattern or if either the
+    /// quantity or the cost portion cannot be parsed.
+    static func parseCostAnnotated(_ input: String, defaultCommodity: String = "") -> Amount? {
+        let trimmed = input.trimmingCharacters(in: .whitespaces)
+        guard let match = trimmed.firstMatch(of: costRegex) else { return nil }
+
+        let qtyStr = String(match.1)
+        let commodity = String(match.2)
+        let costOperator = String(match.3)
+        let costStr = String(match.4).trimmingCharacters(in: .whitespaces)
+
+        let qty = AmountParser.parseNumber(qtyStr)
+        guard qty != 0 else { return nil }
+
+        guard let costAmount = parseSimple(costStr, defaultCommodity: defaultCommodity) else {
+            return nil
+        }
+
+        // Normalize to total cost: hledger's @ means unit cost, @@ means total cost.
+        // Internally we always store total cost — this matches hledger-textual and
+        // simplifies `Amount.formatted()` which always emits `@@`.
+        let totalCostQty: Decimal
+        if costOperator == "@" {
+            totalCostQty = abs(costAmount.quantity * qty)
+        } else {
+            totalCostQty = abs(costAmount.quantity)
+        }
+
+        let cost = CostAmount(
+            commodity: costAmount.commodity,
+            quantity: totalCostQty,
+            style: costAmount.style
+        )
+
+        let style = AmountStyle(
+            commoditySide: .right,
+            commoditySpaced: true,
+            precision: decimalPlaces(in: qtyStr)
+        )
+
+        return Amount(commodity: commodity, quantity: qty, style: style, cost: cost)
+    }
+
+    /// Parse a simple amount (no cost annotation) like `€50.00`, `50,00 EUR`, or `50`.
+    ///
+    /// Returns `nil` for empty input or for plain `0` with no commodity (treated as
+    /// "no amount", consistent with the existing TransactionFormView behaviour).
+    static func parseSimple(_ input: String, defaultCommodity: String = "") -> Amount? {
+        let trimmed = input.trimmingCharacters(in: .whitespaces)
+        guard !trimmed.isEmpty else { return nil }
+
+        let (qty, commodity) = AmountParser.parse(trimmed)
+
+        // Bail out for "no amount" inputs: empty result with no commodity.
+        if qty == 0 && commodity.isEmpty { return nil }
+
+        let effectiveCommodity = commodity.isEmpty ? defaultCommodity : commodity
+        let style = styleFor(commodity: effectiveCommodity, rawInput: trimmed)
+
+        return Amount(commodity: effectiveCommodity, quantity: qty, style: style)
+    }
+
+    // MARK: - Helpers
+
+    /// Build an `AmountStyle` for a parsed commodity, deriving side, spacing and
+    /// precision from the raw input string.
+    ///
+    /// - Single-character commodities (e.g. `€`, `$`) are placed on the left with no space.
+    /// - Multi-character commodities (e.g. `EUR`, `SWDA`) are placed on the right with a space.
+    /// - `decimalMark` is always `.` (the hledger default) so `Amount.formatted()`
+    ///   produces hledger-compatible output.
+    private static func styleFor(commodity: String, rawInput: String) -> AmountStyle {
+        let isSymbol = commodity.count == 1
+        return AmountStyle(
+            commoditySide: isSymbol ? .left : .right,
+            commoditySpaced: !isSymbol,
+            precision: decimalPlaces(in: rawInput)
+        )
+    }
+
+    /// Return the number of decimal places in a raw number string.
+    ///
+    /// Handles both US (`1,000.00`) and European (`1.000,00`) formats using the
+    /// same heuristic as `AmountParser.parseNumber`:
+    /// - If both `.` and `,` are present, the last one is the decimal mark.
+    /// - If only `,` is present, it's treated as decimal when ≤2 digits follow,
+    ///   otherwise as a thousands separator.
+    /// - If only `.` is present, it's always the decimal mark.
+    static func decimalPlaces(in s: String) -> Int {
+        // Strip leading minus and any non-numeric prefix (e.g. currency symbol)
+        let core = s.drop(while: { !$0.isNumber && $0 != "." && $0 != "," })
+        guard !core.isEmpty else { return 0 }
+
+        let hasDot = core.contains(".")
+        let hasComma = core.contains(",")
+        guard hasDot || hasComma else { return 0 }
+
+        let decimalMark: Character
+        if hasDot && hasComma {
+            let lastDot = core.lastIndex(of: ".")!
+            let lastComma = core.lastIndex(of: ",")!
+            decimalMark = lastComma > lastDot ? "," : "."
+        } else if hasComma {
+            let lastComma = core.lastIndex(of: ",")!
+            let afterComma = core[core.index(after: lastComma)...]
+            // ≤2 digits after comma → decimal; otherwise thousands separator
+            guard afterComma.count <= 2 && afterComma.allSatisfy(\.isNumber) else { return 0 }
+            decimalMark = ","
+        } else {
+            decimalMark = "."
+        }
+
+        guard let lastMark = core.lastIndex(of: decimalMark) else { return 0 }
+        return core.distance(from: core.index(after: lastMark), to: core.endIndex)
+    }
+}

--- a/hledger-macos/Views/Transactions/TransactionFormView.swift
+++ b/hledger-macos/Views/Transactions/TransactionFormView.swift
@@ -291,13 +291,13 @@ struct TransactionFormView: View {
     }
 
     private func parseAmountString(_ s: String) -> [Amount] {
-        let trimmed = s.trimmingCharacters(in: .whitespaces)
-        guard !trimmed.isEmpty else { return [] }
-        let (qty, commodity) = AmountParser.parse(trimmed)
-        if qty == 0 && commodity.isEmpty { return [] }
-        let com = commodity.isEmpty ? appState.config.defaultCommodity : commodity
-        let style = appState.styleForCommodity(com)
-        return [Amount(commodity: com, quantity: qty, style: style)]
+        guard let amount = PostingAmountParser.parse(
+            s,
+            defaultCommodity: appState.config.defaultCommodity
+        ) else {
+            return []
+        }
+        return [amount]
     }
 }
 

--- a/hledger-macosTests/hledger_macosTests.swift
+++ b/hledger-macosTests/hledger_macosTests.swift
@@ -145,6 +145,267 @@ struct AmountParserTests {
     }
 }
 
+// MARK: - PostingAmountParser Tests
+
+@Suite("PostingAmountParser")
+struct PostingAmountParserTests {
+
+    // MARK: - Simple amounts
+
+    @Test func parsePlainNumber() {
+        let amount = PostingAmountParser.parse("50.00", defaultCommodity: "€")
+        #expect(amount?.quantity == Decimal(string: "50.00"))
+        #expect(amount?.commodity == "€")
+        #expect(amount?.cost == nil)
+    }
+
+    @Test func parseNegativePlainNumber() {
+        let amount = PostingAmountParser.parse("-123.45", defaultCommodity: "€")
+        #expect(amount?.quantity == Decimal(string: "-123.45"))
+        #expect(amount?.commodity == "€")
+    }
+
+    @Test func parseCurrencyPrefix() {
+        let amount = PostingAmountParser.parse("€500.00")
+        #expect(amount?.quantity == Decimal(string: "500.00"))
+        #expect(amount?.commodity == "€")
+        #expect(amount?.style.commoditySide == .left)
+        #expect(amount?.style.commoditySpaced == false)
+    }
+
+    @Test func parseCurrencySuffix() {
+        let amount = PostingAmountParser.parse("500.00 EUR")
+        #expect(amount?.quantity == Decimal(string: "500.00"))
+        #expect(amount?.commodity == "EUR")
+        #expect(amount?.style.commoditySide == .right)
+        #expect(amount?.style.commoditySpaced == true)
+    }
+
+    @Test func parseEuropeanFormatSimple() {
+        let amount = PostingAmountParser.parse("€50,00")
+        #expect(amount?.quantity == Decimal(string: "50"))
+        #expect(amount?.commodity == "€")
+    }
+
+    @Test func parseEuropeanFormatThousands() {
+        let amount = PostingAmountParser.parse("€1.000,50")
+        #expect(amount?.quantity == Decimal(string: "1000.5"))
+        #expect(amount?.commodity == "€")
+    }
+
+    @Test func parseUSFormat() {
+        let amount = PostingAmountParser.parse("$1,000.50")
+        #expect(amount?.quantity == Decimal(string: "1000.5"))
+        #expect(amount?.commodity == "$")
+    }
+
+    @Test func parseNamedCommodityNoCost() {
+        let amount = PostingAmountParser.parse("10 AAPL")
+        #expect(amount?.quantity == 10)
+        #expect(amount?.commodity == "AAPL")
+        #expect(amount?.cost == nil)
+    }
+
+    @Test func parseNegativeNamedCommodity() {
+        let amount = PostingAmountParser.parse("-5 XDWD")
+        #expect(amount?.quantity == -5)
+        #expect(amount?.commodity == "XDWD")
+        #expect(amount?.cost == nil)
+    }
+
+    // MARK: - Cost annotation: @@ (total cost)
+
+    /// Regression test for the original bug: European decimal in @@ cost.
+    /// Input "-1 SWDA @@ 112,93" was previously rejected by hledger because
+    /// the comma wasn't being normalized to a dot before writing the journal.
+    @Test func parseTotalCostEuropeanDecimal() {
+        let amount = PostingAmountParser.parse("-1 SWDA @@ 112,93", defaultCommodity: "€")
+        #expect(amount?.quantity == -1)
+        #expect(amount?.commodity == "SWDA")
+        #expect(amount?.cost?.quantity == Decimal(string: "112.93"))
+        #expect(amount?.cost?.commodity == "€")
+    }
+
+    @Test func parseTotalCostDotDecimal() {
+        let amount = PostingAmountParser.parse("-5 XDWD @@ €742.55")
+        #expect(amount?.quantity == -5)
+        #expect(amount?.commodity == "XDWD")
+        #expect(amount?.cost?.quantity == Decimal(string: "742.55"))
+        #expect(amount?.cost?.commodity == "€")
+    }
+
+    @Test func parseTotalCostWithCurrencySuffix() {
+        let amount = PostingAmountParser.parse("10 AAPL @@ 1500.00 USD")
+        #expect(amount?.quantity == 10)
+        #expect(amount?.commodity == "AAPL")
+        #expect(amount?.cost?.quantity == Decimal(string: "1500.00"))
+        #expect(amount?.cost?.commodity == "USD")
+    }
+
+    @Test func parseTotalCostEuropeanThousands() {
+        let amount = PostingAmountParser.parse("-5 XDWD @@ €1.000,00")
+        #expect(amount?.quantity == -5)
+        #expect(amount?.cost?.quantity == Decimal(string: "1000"))
+    }
+
+    @Test func parseTotalCostNoExplicitCommodity() {
+        // Cost "112,93" with no commodity → should use defaultCommodity
+        let amount = PostingAmountParser.parse("-1 SWDA @@ 112,93", defaultCommodity: "€")
+        #expect(amount?.cost?.commodity == "€")
+    }
+
+    @Test func parseTotalCostAlwaysPositive() {
+        // hledger requires the @@ cost to be positive, even for sells
+        let amount = PostingAmountParser.parse("-1 SWDA @@ 112.93", defaultCommodity: "€")
+        #expect(amount?.cost?.quantity == Decimal(string: "112.93"))
+    }
+
+    // MARK: - Cost annotation: @ (unit cost)
+
+    @Test func parseUnitCost() {
+        // @ is unit cost: total = qty × unit
+        // -5 XDWD @ €148.00 → total cost = 5 × 148 = 740
+        let amount = PostingAmountParser.parse("-5 XDWD @ €148.00")
+        #expect(amount?.quantity == -5)
+        #expect(amount?.cost?.quantity == Decimal(string: "740"))
+    }
+
+    @Test func parseUnitCostEuropeanDecimal() {
+        // -1 SWDA @ 112,93 → total cost = 1 × 112.93 = 112.93
+        let amount = PostingAmountParser.parse("-1 SWDA @ 112,93", defaultCommodity: "€")
+        #expect(amount?.cost?.quantity == Decimal(string: "112.93"))
+    }
+
+    // MARK: - Edge cases
+
+    @Test func parseEmptyString() {
+        #expect(PostingAmountParser.parse("") == nil)
+        #expect(PostingAmountParser.parse("   ") == nil)
+    }
+
+    @Test func parseZero() {
+        // "0" with no commodity → nil (consistent with previous behavior)
+        #expect(PostingAmountParser.parse("0") == nil)
+    }
+
+    @Test func parseGarbageString() {
+        #expect(PostingAmountParser.parse("not a number") == nil)
+    }
+
+    @Test func parseCostWithoutCommodity() {
+        // "@@ 100" has no quantity/commodity prefix → invalid
+        #expect(PostingAmountParser.parseCostAnnotated("@@ 100") == nil)
+    }
+
+    @Test func parseCostWithoutCostValue() {
+        // Missing cost amount after @@ is caught by the regex (requires .+)
+        #expect(PostingAmountParser.parseCostAnnotated("-1 SWDA @@") == nil)
+    }
+
+    @Test func parseCostWithInvalidCostAmount() {
+        // Cost portion cannot be parsed as a number
+        #expect(PostingAmountParser.parseCostAnnotated("-1 SWDA @@ garbage") == nil)
+    }
+
+    // MARK: - Roundtrip: parse → format → hledger-compatible output
+
+    /// Critical test: European input must produce hledger-compatible output.
+    /// User types `-1 SWDA @@ 112,93` (Italian) → journal must contain `112.93`.
+    @Test func roundtripEuropeanInputProducesDotOutput() {
+        let amount = PostingAmountParser.parse("-1 SWDA @@ 112,93", defaultCommodity: "€")!
+        let formatted = amount.formatted()
+        // Must contain the dot-normalized cost, no comma
+        #expect(formatted.contains("112.93"))
+        #expect(!formatted.contains("112,93"))
+        #expect(formatted.contains("@@"))
+    }
+
+    @Test func roundtripSimpleEuropeanInputProducesDotOutput() {
+        let amount = PostingAmountParser.parse("€50,00")!
+        let formatted = amount.formatted()
+        #expect(formatted.contains("50.00"))
+        #expect(!formatted.contains("50,00"))
+    }
+
+    @Test func roundtripCostAnnotatedFormatIncludesCostMarker() {
+        let amount = PostingAmountParser.parse("-5 XDWD @@ €742.55")!
+        let formatted = amount.formatted()
+        #expect(formatted.contains("XDWD"))
+        #expect(formatted.contains("@@"))
+        #expect(formatted.contains("742.55"))
+    }
+
+    /// When editing an existing transaction, the prefilled amount string comes from
+    /// `Amount.formatted()`. Re-parsing that string must yield an equivalent Amount,
+    /// so the user can edit and save without losing information.
+    @Test func roundtripCostAnnotatedFullCycle() {
+        let parsed = PostingAmountParser.parse("-5 XDWD @@ €742.55")!
+        let formatted = parsed.formatted()
+        let reparsed = PostingAmountParser.parse(formatted)!
+
+        #expect(reparsed.quantity == parsed.quantity)
+        #expect(reparsed.commodity == parsed.commodity)
+        #expect(reparsed.cost?.quantity == parsed.cost?.quantity)
+        #expect(reparsed.cost?.commodity == parsed.cost?.commodity)
+    }
+
+    @Test func roundtripEuropeanInputFullCycle() {
+        // User types European format → formatted in hledger format → reparsed
+        let parsed = PostingAmountParser.parse("-1 SWDA @@ 112,93", defaultCommodity: "€")!
+        let formatted = parsed.formatted()
+        let reparsed = PostingAmountParser.parse(formatted)!
+
+        #expect(reparsed.quantity == -1)
+        #expect(reparsed.commodity == "SWDA")
+        #expect(reparsed.cost?.quantity == Decimal(string: "112.93"))
+        #expect(reparsed.cost?.commodity == "€")
+    }
+
+    // MARK: - decimalPlaces helper
+
+    @Test func decimalPlacesNoSeparator() {
+        #expect(PostingAmountParser.decimalPlaces(in: "50") == 0)
+        #expect(PostingAmountParser.decimalPlaces(in: "1000") == 0)
+    }
+
+    @Test func decimalPlacesDotDecimal() {
+        #expect(PostingAmountParser.decimalPlaces(in: "50.00") == 2)
+        #expect(PostingAmountParser.decimalPlaces(in: "50.5") == 1)
+        #expect(PostingAmountParser.decimalPlaces(in: "50.123") == 3)
+    }
+
+    @Test func decimalPlacesCommaDecimal() {
+        #expect(PostingAmountParser.decimalPlaces(in: "50,00") == 2)
+        #expect(PostingAmountParser.decimalPlaces(in: "112,93") == 2)
+        #expect(PostingAmountParser.decimalPlaces(in: "50,5") == 1)
+    }
+
+    @Test func decimalPlacesEuropeanThousands() {
+        // "1.000,50" → European: dot is thousands, comma is decimal → 2 places
+        #expect(PostingAmountParser.decimalPlaces(in: "1.000,50") == 2)
+    }
+
+    @Test func decimalPlacesUSThousands() {
+        // "1,000.50" → US: comma is thousands, dot is decimal → 2 places
+        #expect(PostingAmountParser.decimalPlaces(in: "1,000.50") == 2)
+    }
+
+    @Test func decimalPlacesCommaAsThousands() {
+        // "1,000" → 3 digits after comma → thousands separator → 0 places
+        #expect(PostingAmountParser.decimalPlaces(in: "1,000") == 0)
+    }
+
+    @Test func decimalPlacesWithCurrencyPrefix() {
+        #expect(PostingAmountParser.decimalPlaces(in: "€50.00") == 2)
+        #expect(PostingAmountParser.decimalPlaces(in: "-€50,00") == 2)
+    }
+
+    @Test func decimalPlacesNegative() {
+        #expect(PostingAmountParser.decimalPlaces(in: "-50.00") == 2)
+        #expect(PostingAmountParser.decimalPlaces(in: "-112,93") == 2)
+    }
+}
+
 // MARK: - AmountFormatter Tests
 
 @Suite("AmountFormatter")


### PR DESCRIPTION
Closes #83

## Summary
- Posting amounts like `-1 SWDA @@ 112,93` were rejected by hledger because the parser in `TransactionFormView` did not recognize the cost-annotation pattern at all, so the raw string (including the comma) was handed straight to hledger.
- Introduces a dedicated `PostingAmountParser` helper that handles simple amounts and `@`/`@@` cost annotations, normalizing both US (`1,000.00`) and European (`1.000,00`) number formats into hledger-compatible output (`.` decimal mark).
- `TransactionFormView.parseAmountString` now delegates to the new parser, and the logic is covered by 36 isolated unit tests — no `AppState` dependency needed.

## Details
- **`hledger-macos/Config/PostingAmountParser.swift`** (new)
  - `parse(_:defaultCommodity:)` — main entry point: tries cost-annotated pattern first, falls back to simple amount.
  - `parseCostAnnotated(_:defaultCommodity:)` — handles `-5 XDWD @@ €742,55` / `-5 XDWD @ €148.518`. `@` (unit cost) is normalized to total cost internally, matching `hledger-textual`.
  - `parseSimple(_:defaultCommodity:)` — handles `€50,00`, `50.00 EUR`, `10 AAPL`, plain numbers, etc.
  - `decimalPlaces(in:)` — precision helper that understands both US and European separators.
  - Uses `AmountParser.parseNumber` under the hood so number normalization stays in a single place.
  - Always emits `decimalMark = "."` so `Amount.formatted()` produces journal-compatible output regardless of what the user typed.
- **`hledger-macos/Views/Transactions/TransactionFormView.swift`**
  - `parseAmountString` reduced to a single delegation call.
- **`hledger-macosTests/hledger_macosTests.swift`**
  - New `@Suite("PostingAmountParser")` with 36 tests covering: simple amounts, `@@` total cost, `@` unit cost (with multiplication), European/US formats, thousands separators, edge cases (empty, zero, garbage, missing cost), `decimalPlaces` helper, and full parse→format→reparse roundtrips.
  - Regression test for the original bug: `parseTotalCostEuropeanDecimal` (`-1 SWDA @@ 112,93`).
  - `roundtripEuropeanInputProducesDotOutput` asserts that the serialized form contains `112.93` and never `112,93`.

## Test plan
- [x] `xcodebuild test … -only-testing:hledger-macosTests/PostingAmountParserTests` — 36/36 pass
- [x] `xcodebuild test … -only-testing:hledger-macosTests/AmountParserTests` — 21/21 still pass (no regressions)
- [x] `xcodebuild build` — build succeeds
- [x] Manual: edit an existing cost-annotated transaction and re-save to confirm the roundtrip works end-to-end