### PR TITLE
chore: bump version to 0.1.6

### DIFF
--- a/hledger-macos.xcodeproj/project.pbxproj
+++ b/hledger-macos.xcodeproj/project.pbxproj
@@ -414,7 +414,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 0.1.5;
+				MARKETING_VERSION = 0.1.6;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.thesmokinator.hledger-macos";
 				PRODUCT_NAME = "hledger for Mac";
 				REGISTER_APP_GROUPS = YES;
@@ -448,7 +448,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 0.1.5;
+				MARKETING_VERSION = 0.1.6;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.thesmokinator.hledger-macos";
 				PRODUCT_NAME = "hledger for Mac";
 				REGISTER_APP_GROUPS = YES;


### PR DESCRIPTION
Version bump from 0.1.5 to 0.1.6.

## Included since v0.1.5
- thesmokinator/hledger-macos#82 — fix: parse cost annotations with European decimals in posting form

## Test plan
- [ ] CI build passes
- [ ] After merge, tag `v0.1.6` to trigger release pipeline