### PR TITLE
ci: add test workflow for PRs (#101)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,7 +35,10 @@ jobs:
             -destination 'platform=macOS' \
             -only-testing:hledger-macosTests \
             -enableCodeCoverage YES \
-            -resultBundlePath TestResults.xcresult
+            -resultBundlePath TestResults.xcresult \
+            CODE_SIGNING_ALLOWED=NO \
+            CODE_SIGNING_REQUIRED=NO \
+            CODE_SIGN_IDENTITY=""
 
       - name: Upload test results
         if: always()

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,46 @@
+name: Tests
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+jobs:
+  test:
+    runs-on: macos-26
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Install hledger
+        run: brew install hledger
+
+      - name: Verify hledger
+        run: hledger --version
+
+      - name: Run unit tests
+        run: |
+          xcodebuild test \
+            -project hledger-macos.xcodeproj \
+            -scheme hledger-macos \
+            -destination 'platform=macOS' \
+            -only-testing:hledger-macosTests \
+            -enableCodeCoverage YES \
+            -resultBundlePath TestResults.xcresult
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: TestResults-${{ github.run_id }}
+          path: TestResults.xcresult
+          retention-days: 14


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/test.yml` triggered on `pull_request` and pushes to `main`
- Installs `hledger` via Homebrew so the `Integration` suite runs with full fidelity (parses real `hledger print -O json` output across European/US/Swiss/Indian fixtures)
- Runs the `hledger-macosTests` target via `xcodebuild test` (UI tests excluded via `-only-testing`)
- Uploads `TestResults.xcresult` as artifact (`if: always()`) for post-mortem

## Conventions inherited from `release.yml`
- `runs-on: macos-26`
- `actions/checkout@v5`
- `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true`
- `-project hledger-macos.xcodeproj -scheme hledger-macos`

## What is intentionally NOT in this PR
- Coverage threshold gate (premature before #94/#95 land)
- Coverage parsing / PR comment via `xccov` (same reason)
- Branch protection rules (manual, configure in Settings after first green run)
- SPM/DerivedData caching (optimization, defer)
- Separate workflow for UI tests (eventual `workflow_dispatch`)

## Local verification
Ran `xcodebuild test -project hledger-macos.xcodeproj -scheme hledger-macos -destination 'platform=macOS' -only-testing:hledger-macosTests -enableCodeCoverage YES` locally — **177 tests in 23 suites passed in 2.45s**, including the `Integration` suite that requires the `hledger` binary.

## Test plan
- [ ] Workflow run triggers on this PR
- [ ] `brew install hledger` succeeds on the runner
- [ ] All 177 tests pass on CI (parity with local)
- [ ] `TestResults.xcresult` artifact is downloadable from the workflow run page

Closes #101