### PR TITLE
test: fill PostingAmountParser coverage gaps (#95)

### DIFF
--- a/hledger-macosTests/hledger_macosTests.swift
+++ b/hledger-macosTests/hledger_macosTests.swift
@@ -404,6 +404,72 @@ struct PostingAmountParserTests {
         #expect(PostingAmountParser.decimalPlaces(in: "-50.00") == 2)
         #expect(PostingAmountParser.decimalPlaces(in: "-112,93") == 2)
     }
+
+    // MARK: - Issue #95 gaps: literal #83 regression and edge cases
+
+    /// Literal regression test for the exact string in issue #83:
+    /// `€` symbol prefix + comma decimal, no thousands separator.
+    /// The pre-existing `parseTotalCostEuropeanDecimal` covers a similar case
+    /// without the `€` symbol; this asserts the literal failing input.
+    @Test func parseTotalCostLiteralIssue83() {
+        let amount = PostingAmountParser.parse("-5 XDWD @@ €742,55")
+        #expect(amount?.quantity == -5)
+        #expect(amount?.commodity == "XDWD")
+        #expect(amount?.cost?.quantity == Decimal(string: "742.55"))
+        #expect(amount?.cost?.commodity == "€")
+        // Formatted output must use `.` (hledger-compatible), never `,`
+        let formatted = amount!.formatted()
+        #expect(formatted.contains("742.55"))
+        #expect(!formatted.contains("742,55"))
+    }
+
+    @Test func parseTotalCostExtraWhitespaceAroundOperator() {
+        // Multiple spaces around @@ are tolerated by `\s+` in the regex
+        let amount = PostingAmountParser.parse("-5 XDWD   @@   €742,55")
+        #expect(amount?.quantity == -5)
+        #expect(amount?.cost?.quantity == Decimal(string: "742.55"))
+    }
+
+    @Test func parseTotalCostZeroValue() {
+        // Zero cost is valid: e.g. a free promotional share
+        let amount = PostingAmountParser.parse("-5 XDWD @@ €0")
+        #expect(amount?.cost?.quantity == 0)
+        #expect(amount?.cost?.commodity == "€")
+    }
+
+    @Test func parseTotalCostZeroValueEuropeanDecimal() {
+        let amount = PostingAmountParser.parse("-5 XDWD @@ €0,00")
+        #expect(amount?.cost?.quantity == 0)
+    }
+
+    @Test func parseTotalCostNegativeInputNormalizedToPositive() {
+        // hledger requires @@ cost to be positive even when the user types a
+        // negative number. The parser must apply `abs()` so the formatted
+        // output never contains a negative cost.
+        let amount = PostingAmountParser.parse("-5 XDWD @@ -€100,00")
+        #expect(amount?.quantity == -5)
+        #expect(amount?.cost?.quantity == Decimal(string: "100"))
+        let formatted = amount!.formatted()
+        #expect(!formatted.contains("@@ -"))
+        #expect(!formatted.contains("@@-"))
+    }
+
+    @Test func parseSimpleDirectCallReturnsNonNil() {
+        // The existing suite only tests via top-level `parse()`. Cover the
+        // public `parseSimple` entry point directly.
+        let amount = PostingAmountParser.parseSimple("€50,00")
+        #expect(amount?.quantity == 50)
+        #expect(amount?.commodity == "€")
+        #expect(amount?.cost == nil)
+    }
+
+    @Test func parseCostAnnotatedReturnsNilForPlainSimpleAmount() {
+        // The cost regex must not false-match a plain amount with no `@`.
+        // Calling `parseCostAnnotated` directly on `€50,00` should return nil,
+        // forcing callers (like `parse`) to fall back to `parseSimple`.
+        #expect(PostingAmountParser.parseCostAnnotated("€50,00") == nil)
+        #expect(PostingAmountParser.parseCostAnnotated("-1 SWDA") == nil)
+    }
 }
 
 // MARK: - AmountFormatter Tests


### PR DESCRIPTION
## Summary
After auditing the existing `PostingAmountParser` suite (35 tests, shipped with #82) against the issue checklist, most of #95 was already done. This PR adds **7 targeted tests** for the genuine remaining gaps. The issue body has been updated to reflect this.

Test count: **213 → 220**, all green in ~0.65s locally.

## New tests
1. `parseTotalCostLiteralIssue83` — the exact string from the original bug report (`-5 XDWD @@ €742,55`: € symbol + comma decimal, **no thousands separator**). The pre-existing regression test used `-1 SWDA @@ 112,93` which lacks the € symbol; this asserts the literal failing input.
2. `parseTotalCostExtraWhitespaceAroundOperator` — `\s+` in the regex must tolerate multiple spaces around `@@`.
3. `parseTotalCostZeroValue` — `-5 XDWD @@ €0` (e.g. free promotional share); cost.quantity must be 0, not nil.
4. `parseTotalCostZeroValueEuropeanDecimal` — `-5 XDWD @@ €0,00` variant.
5. `parseTotalCostNegativeInputNormalizedToPositive` — `-5 XDWD @@ -€100,00`. hledger requires `@@` cost to be positive; the parser must apply `abs()`. Asserts the formatted output never contains `@@ -` or `@@-`.
6. `parseSimpleDirectCallReturnsNonNil` — the existing suite only tests via top-level `parse()`; this covers the public `parseSimple` entry point directly.
7. `parseCostAnnotatedReturnsNilForPlainSimpleAmount` — the cost regex must not false-match plain amounts. Calling `parseCostAnnotated` directly on `€50,00` and `-1 SWDA` (no `@`) must return nil.

## What was dropped from the original draft
A test asserting `-5 XDWD@@€742,55` (zero whitespace around `@@`) returns nil. The parser actually returns a non-nil (likely garbage) Amount in that case because `parseSimple` is permissive. That's a separate bug — the no-whitespace input should arguably be supported, or rejected cleanly. Belongs in its own issue, not in a test PR.

## Local verification
```
✔ Test run with 220 tests in 33 suites passed after 0.653 seconds.
** TEST SUCCEEDED **
```

Closes #95