### PR TITLE
chore: bump version to 0.2.0

### DIFF
--- a/hledger-macos.xcodeproj/project.pbxproj
+++ b/hledger-macos.xcodeproj/project.pbxproj
@@ -414,7 +414,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 0.1.6;
+				MARKETING_VERSION = 0.2.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.thesmokinator.hledger-macos";
 				PRODUCT_NAME = "hledger for Mac";
 				REGISTER_APP_GROUPS = YES;
@@ -448,7 +448,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 0.1.6;
+				MARKETING_VERSION = 0.2.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.thesmokinator.hledger-macos";
 				PRODUCT_NAME = "hledger for Mac";
 				REGISTER_APP_GROUPS = YES;


### PR DESCRIPTION
## Summary
Bumps `MARKETING_VERSION` from `0.1.6` to `0.2.0` in the main app target (Debug + Release configs). Test target versions left at `1.0` as before.

This closes the **v0.2.0 milestone** (4/4 issues complete):
- #101 — CI workflow on PRs
- #94 — JournalWriter test suite (36 tests covering all routing strategies, replace/delete/updateStatus, backup/restore on validation failure)
- #95 — PostingAmountParser coverage gaps (literal #83 regression + edge cases)
- #99 — TransactionFormatter alignment and round-trip tests

## Test suite growth
- **177 → 232 tests** (+55, +31%)
- All green on CI in ~1.7s
- Coverage now solid on the three highest data-corruption-risk components: `JournalWriter`, `PostingAmountParser`, `TransactionFormatter`

## Release process
After this PR is merged, push tag `v0.2.0` from `main` to trigger `.github/workflows/release.yml` which builds, notarizes, and publishes the DMG.

## Test plan
- [ ] CI green on this PR (verifies the version bump didn't break the project file)
- [ ] After merge: tag `v0.2.0` triggers the release workflow