### PR TITLE
docs: add Tests badge to README, drop License section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # hledger for Mac
 
+[![Tests](https://github.com/thesmokinator/hledger-macos/actions/workflows/test.yml/badge.svg)](https://github.com/thesmokinator/hledger-macos/actions/workflows/test.yml)
+
 A native macOS app for [hledger](https://hledger.org) plain-text accounting. Manage transactions, budgets, recurring rules, view summaries, track investments, and generate financial reports — all from a native SwiftUI interface.
 
 Built with Swift and SwiftUI. Requires macOS 26+.
@@ -134,7 +136,3 @@ open hledger-macos.xcodeproj
 ```
 
 Build and run with Xcode (Cmd+R). Run tests with Cmd+U.
-
-## License
-
-MIT


### PR DESCRIPTION
## Summary
- Adds the GitHub Actions Tests workflow status badge right after the H1
- Removes the bottom \`## License / MIT\` section since \`LICENSE.md\` already documents this — having both is redundant

## Coverage badge
Deferred to #117 (created with the v0.2.1 milestone). The decision among Codecov / Shields+Gist / DIY needs explicit input plus an external setup step (signup or PAT), which doesn't fit a quick docs PR.

## Test plan
- [x] CI green
- [x] Badge renders \"passing\" on the rendered README after merge