### PR TITLE
docs: add Release, License and Platform badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # hledger for Mac
 
 [![Tests](https://github.com/thesmokinator/hledger-macos/actions/workflows/test.yml/badge.svg)](https://github.com/thesmokinator/hledger-macos/actions/workflows/test.yml)
+[![Latest Release](https://img.shields.io/github/v/release/thesmokinator/hledger-macos)](https://github.com/thesmokinator/hledger-macos/releases/latest)
+[![License](https://img.shields.io/github/license/thesmokinator/hledger-macos)](LICENSE.md)
+![Platform](https://img.shields.io/badge/platform-macOS%2026%2B-blue)
 
 A native macOS app for [hledger](https://hledger.org) plain-text accounting. Manage transactions, budgets, recurring rules, view summaries, track investments, and generate financial reports — all from a native SwiftUI interface.
 


### PR DESCRIPTION
## Summary
Adds three informational badges next to the existing Tests badge in the README:

- **Latest Release** — `shields.io/github/v/release` reading the GitHub releases API; auto-updates and links to the latest release page
- **License** — `shields.io/github/license` auto-detecting MIT from `LICENSE.md` (SPDX); links to `LICENSE.md`
- **Platform** — static `macOS 26+` informational badge

All endpoints are shields.io (no third-party services, no signups, no tokens). The first two auto-update from GitHub data, the third is static.

## Coverage badge — dropped
The original v0.2.1 plan included a coverage badge tracking issue (#117). After measuring the actual coverage (logic-layer 63%, global 22.7% diluted by 12349 lines of SwiftUI Views which we don't unit-test), the badge was deemed not worth the third-party Codecov dependency. Closed #117 with `not planned` and a writeup of the reasoning.

## Test plan
- [ ] CI green
- [ ] All 4 badges render on the README after merge