### PR TITLE
chore: bump version to 0.2.1

### DIFF
--- a/hledger-macos.xcodeproj/project.pbxproj
+++ b/hledger-macos.xcodeproj/project.pbxproj
@@ -414,7 +414,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 0.2.0;
+				MARKETING_VERSION = 0.2.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.thesmokinator.hledger-macos";
 				PRODUCT_NAME = "hledger for Mac";
 				REGISTER_APP_GROUPS = YES;
@@ -448,7 +448,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 0.2.0;
+				MARKETING_VERSION = 0.2.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.thesmokinator.hledger-macos";
 				PRODUCT_NAME = "hledger for Mac";
 				REGISTER_APP_GROUPS = YES;


### PR DESCRIPTION
## Summary
Bumps `MARKETING_VERSION` from `0.2.0` to `0.2.1` in the main app target (Debug + Release configs). Test target versions left at `1.0`.

This closes the **v0.2.1 milestone** (5/5 issues, 4 test PRs + 1 not-planned):

| # | Title | Tests added |
|---|---|---|
| #96 | HledgerBackend parser test suite | +45 |
| #97 | BinaryDetector coverage | +6 |
| #98 | JournalFileResolver coverage | +10 |
| #100 | PriceFetcher / BudgetManager / RecurringManager | +33 |
| #117 | Coverage badge | dropped (not planned) |

**Plus bonus README polish** from #118 and #125: Tests, Latest Release, License, and Platform badges.

## Test suite growth (cumulative since v0.2.0)
- v0.2.0 baseline: **177** tests
- v0.2.0 ship: **232** (+55, +31%)
- v0.2.1 ship: **326** (+94, +41%)
- Total since v0.1.6: **+149 tests, +84%**

All green on CI in ~1.7s.

## Coverage measurement (logic layer only)
Measured locally with `xccov view --report` after the v0.2.1 work landed:
- **Backend: 74.4%** (1813 / 2436 lines)
- **Config: 70.8%** (223 / 315)
- **Models: 58.5%** (189 / 323)
- **Services: 39.9%** (500 / 1253)
- **Logic layer total: 63.0%** (Backend + Config + Models + Services, 4327 lines)
- **Critical files all ≥92%**: TransactionFormatter (100%), JournalFileResolver (93.2%), JournalWriter (92.5%), SubprocessRunner (95.7%)

## Followups in v0.2.2
- #120 — refactor BinaryDetector to extract `FileSystemAccess` and `ShellRunner` protocols (unlocks the 4 untestable cases from #97)
- #121 — bug: BinaryDetector accepts directory paths as hledger binary

## Release process
After merge, push tag `v0.2.1` from `main` to trigger `.github/workflows/release.yml` which builds, notarizes and publishes the DMG.

## Test plan
- [ ] CI green on this PR
- [ ] After merge: tag `v0.2.1` triggers the release workflow