### PR TITLE
docs: add US-format example journals (#127)

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,13 +68,16 @@ Accepts a file path or a directory containing journal files (auto-detects `main.
 
 ## Examples
 
-The [`examples/`](examples/) directory contains sample journals:
+The [`examples/`](examples/) directory contains sample journals in both EU and US conventions:
 
-| Example | Description |
-|---------|-------------|
-| [`hledger-simple/`](examples/hledger-simple/) | Single-file journal with basic transactions, comments, balance assertions, multi-commodity |
-| [`hledger-multi-file/`](examples/hledger-multi-file/) | Multi-file journal with glob routing and investments |
-| [`multicommodity.journal`](examples/multicommodity.journal) | Multi-currency edge cases |
+| Example | Format | Description |
+|---------|--------|-------------|
+| [`hledger-simple/`](examples/hledger-simple/) | EU (`€1.234,56`) | Single-file journal with basic transactions, comments, balance assertions, multi-commodity |
+| [`hledger-simple-us/`](examples/hledger-simple-us/) | US (`$1,234.56`) | Same structure as `hledger-simple/` but with `$`, US number format and CapitalCase accounts |
+| [`hledger-multi-file/`](examples/hledger-multi-file/) | EU | Multi-file journal with glob routing and investments |
+| [`multicommodity.journal`](examples/multicommodity.journal) | EU base | Multi-currency edge cases (`€` + named-commodity ETFs) |
+| [`multicommodity-us.journal`](examples/multicommodity-us.journal) | US base | Multi-currency edge cases (`$` + AAPL/SPY) |
+| [`csv-import/`](examples/csv-import/) | mixed | Sample CSV files and `.rules` for the CSV import wizard |
 
 ## Keyboard Shortcuts
 

--- a/examples/hledger-simple-us/main.journal
+++ b/examples/hledger-simple-us/main.journal
@@ -1,0 +1,315 @@
+; hledger for Mac — demo journal (single file, US format)
+; Point Settings > Journal File to this file or its parent directory.
+;
+; This is the US-style companion to ../hledger-simple/main.journal:
+; - $ commodity (left-side, no space)
+; - US number format: $1,234.56 (comma thousands, dot decimal)
+; - CapitalCase account names (Assets:Checking, Expenses:Groceries)
+
+account Assets:Checking
+account Assets:Savings
+account Expenses:Food:Groceries
+account Expenses:Food:Restaurant
+account Expenses:Housing:Rent
+account Expenses:Housing:Utilities
+account Expenses:Transport
+account Expenses:Subscriptions
+account Expenses:Shopping
+account Expenses:Health
+account Expenses:Entertainment
+account Income:Salary
+account Income:Freelance
+account Liabilities:CreditCard
+account Liabilities:CarLoan
+
+; === JANUARY 2026 ===
+
+2026-01-01 * Opening balances
+    Assets:Checking                   $5,200.00
+    Assets:Savings                    $14,500.00
+    Liabilities:CarLoan               $-9,200.00
+    Equity:OpeningBalances
+
+2026-01-02 * Bi-weekly paycheck
+    Assets:Checking                   $1,850.00
+    Income:Salary
+
+2026-01-03 * Rent
+    Expenses:Housing:Rent             $1,450.00
+    Assets:Checking
+
+2026-01-04 * Trader Joe's
+    Expenses:Food:Groceries           $87.42
+    Assets:Checking
+
+2026-01-07 * Comcast internet
+    Expenses:Housing:Utilities        $79.99
+    Assets:Checking
+
+2026-01-10 * Netflix
+    Expenses:Subscriptions            $15.49
+    Assets:Checking
+
+2026-01-11 * Whole Foods
+    Expenses:Food:Groceries           $112.30
+    Assets:Checking
+
+2026-01-14 * Chipotle
+    Expenses:Food:Restaurant          $14.75
+    Assets:Checking
+
+2026-01-15 * Freelance invoice
+    Assets:Checking                   $625.00
+    Income:Freelance
+
+2026-01-16 * Bi-weekly paycheck
+    Assets:Checking                   $1,850.00
+    Income:Salary
+
+2026-01-17 * Shell gas
+    Expenses:Transport                $48.20
+    Assets:Checking
+
+2026-01-18 * Costco
+    Expenses:Food:Groceries           $186.55
+    Assets:Checking
+
+2026-01-20 * Car loan payment
+    Liabilities:CarLoan               $385.00
+    Assets:Checking
+
+2026-01-22 * Planet Fitness
+    Expenses:Health                   $24.99
+    Assets:Checking
+
+2026-01-25 * Amazon order
+    Expenses:Shopping                 $42.18
+    Liabilities:CreditCard
+
+2026-01-27 * Credit card payment
+    Liabilities:CreditCard            $42.18
+    Assets:Checking
+
+2026-01-28 * Transfer to savings
+    Assets:Savings                    $400.00
+    Assets:Checking
+
+; === FEBRUARY 2026 ===
+
+2026-02-01 * Bi-weekly paycheck
+    Assets:Checking                   $1,850.00
+    Income:Salary
+
+2026-02-02 * Rent
+    Expenses:Housing:Rent             $1,450.00
+    Assets:Checking
+
+2026-02-04 * Trader Joe's
+    Expenses:Food:Groceries           $76.20
+    Assets:Checking
+
+2026-02-06 * AT&T phone bill
+    Expenses:Housing:Utilities        $65.00
+    Assets:Checking
+
+2026-02-10 * Netflix
+    Expenses:Subscriptions            $15.49
+    Assets:Checking
+
+2026-02-10 * Spotify
+    Expenses:Subscriptions            $11.99
+    Assets:Checking
+
+2026-02-12 * Whole Foods
+    Expenses:Food:Groceries           $94.65
+    Assets:Checking
+
+2026-02-13 * Bi-weekly paycheck
+    Assets:Checking                   $1,850.00
+    Income:Salary
+
+2026-02-14 * Valentine's dinner
+    Expenses:Food:Restaurant          $112.50
+    Liabilities:CreditCard
+
+2026-02-16 * Uber rides
+    Expenses:Transport                $38.40
+    Assets:Checking
+
+2026-02-18 * Trader Joe's
+    Expenses:Food:Groceries           $68.90
+    Assets:Checking
+
+2026-02-20 * Car loan payment
+    Liabilities:CarLoan               $385.00
+    Assets:Checking
+
+2026-02-22 * Planet Fitness
+    Expenses:Health                   $24.99
+    Assets:Checking
+
+2026-02-24 * Movie night
+    Expenses:Entertainment            $32.00
+    Assets:Checking
+
+2026-02-25 * Nike sneakers
+    Expenses:Shopping                 $145.00
+    Liabilities:CreditCard
+
+2026-02-27 * Credit card payment
+    Liabilities:CreditCard            $257.50
+    Assets:Checking
+
+2026-02-28 * Transfer to savings
+    Assets:Savings                    $350.00
+    Assets:Checking
+
+; === MARCH 2026 ===
+
+2026-03-01 * Bi-weekly paycheck
+    Assets:Checking                   $1,850.00
+    Income:Salary
+
+2026-03-02 * Rent
+    Expenses:Housing:Rent             $1,450.00
+    Assets:Checking
+
+2026-03-03 * Costco
+    Expenses:Food:Groceries           $204.18
+    Assets:Checking
+
+2026-03-05 * PG&E electric
+    Expenses:Housing:Utilities        $94.30
+    Assets:Checking
+
+2026-03-07 * Sushi place
+    Expenses:Food:Restaurant          $58.00
+    Assets:Checking
+
+2026-03-10 * Netflix
+    Expenses:Subscriptions            $15.49
+    Assets:Checking
+
+2026-03-10 * Spotify
+    Expenses:Subscriptions            $11.99
+    Assets:Checking
+
+2026-03-12 * Whole Foods
+    Expenses:Food:Groceries           $103.75
+    Assets:Checking
+
+2026-03-13 * Bi-weekly paycheck
+    Assets:Checking                   $1,850.00
+    Income:Salary
+
+2026-03-15 * Freelance invoice
+    Assets:Checking                   $1,200.00
+    Income:Freelance
+
+2026-03-16 * Shell gas
+    Expenses:Transport                $52.10
+    Assets:Checking
+
+2026-03-18 * Trader Joe's
+    Expenses:Food:Groceries           $79.40
+    Assets:Checking
+
+2026-03-20 * Car loan payment
+    Liabilities:CarLoan               $385.00
+    Assets:Checking
+
+2026-03-22 * Planet Fitness
+    Expenses:Health                   $24.99
+    Assets:Checking
+
+2026-03-24 * Concert tickets
+    Expenses:Entertainment            $85.00
+    Liabilities:CreditCard
+
+2026-03-25 * Books on Amazon
+    Expenses:Shopping                 $54.20
+    Assets:Checking
+
+2026-03-27 * Credit card payment
+    Liabilities:CreditCard            $85.00
+    Assets:Checking
+
+2026-03-28 * Transfer to savings
+    Assets:Savings                    $500.00
+    Assets:Checking
+
+; === APRIL 2026 ===
+
+2026-04-01 * Bi-weekly paycheck
+    Assets:Checking                   $1,850.00
+    Income:Salary
+
+2026-04-01 * Rent
+    Expenses:Housing:Rent             $1,450.00
+    Assets:Checking
+
+2026-04-02 * Trader Joe's
+    Expenses:Food:Groceries           $91.05
+    Assets:Checking
+
+2026-04-03 * PG&E electric
+    Expenses:Housing:Utilities        $88.50
+    Assets:Checking
+
+2026-04-05 * Diner brunch
+    Expenses:Food:Restaurant          $42.00
+    Assets:Checking
+
+2026-04-07 * Whole Foods
+    Expenses:Food:Groceries           $122.30
+    Assets:Checking
+
+2026-04-10 * Netflix
+    Expenses:Subscriptions            $15.49
+    Assets:Checking
+
+2026-04-10 * Spotify
+    Expenses:Subscriptions            $11.99
+    Assets:Checking
+
+2026-04-12 * Shell gas
+    Expenses:Transport                $49.80
+    Assets:Checking
+
+2026-04-15 * Dentist visit
+    Expenses:Health                   $185.00
+    Assets:Checking
+
+2026-04-18 * Costco
+    Expenses:Food:Groceries           $217.40
+    Assets:Checking
+
+2026-04-20 * Car loan payment
+    Liabilities:CarLoan               $385.00
+    Assets:Checking
+
+2026-04-22 * Planet Fitness
+    Expenses:Health                   $24.99
+    Assets:Checking
+
+2026-04-25 * Museum membership
+    Expenses:Entertainment            $75.00
+    Assets:Checking
+
+; === EDGE CASES: comments, balance assertions, multi-commodity ===
+
+2026-04-26 * Weekly groceries  ; family shopping run
+    Expenses:Food:Groceries                         $128.45  ; organic produce
+    Assets:Checking  ; paid with debit card
+
+2026-04-27 * Mid-month paycheck with assertion
+    Assets:Checking                   $1,850.00 = $10,102.64
+    Income:Salary
+
+2026-04-28 * Freelance EUR payment  ; European client
+    Assets:Checking                   €450.00
+    Income:Freelance
+
+2026-04-29 * Amazon UK purchase
+    Expenses:Shopping                 £25.00
+    Assets:Checking                   $-32.00

--- a/examples/multicommodity-us.journal
+++ b/examples/multicommodity-us.journal
@@ -1,0 +1,58 @@
+; Test journal covering multi-commodity edge cases for hledger (US format).
+;
+; This is the US-style companion to ./multicommodity.journal:
+; - $ as base currency
+; - AAPL / SPY as named-commodity examples (US-style ETFs)
+; - Cost annotations in $ with US format
+
+; --- Account with single commodity (should work fine)
+2026-01-01 * Opening Bank
+    Assets:Bank                          $12,000.00
+    Equity:Opening
+
+; --- Account with non-currency commodity (AAPL, SPY)
+2026-01-15 * Buy AAPL
+    Assets:Investments:AAPL              25 AAPL @@ $4,287.50
+    Assets:Bank
+
+2026-01-16 * Buy SPY
+    Assets:Investments:SPY               10 SPY @@ $5,124.30
+    Assets:Bank
+
+; --- Account that accumulates MULTIPLE commodities (the problematic case)
+; This wallet receives both USD and EUR
+2026-02-01 * Freelance USD
+    Assets:Wallet                        $750.00
+    Income:Freelance
+
+2026-02-15 * Freelance EUR
+    Assets:Wallet                        €400.00
+    Income:Freelance
+
+; --- Expense in foreign currency
+2026-03-01 * Hotel in Paris
+    Expenses:Travel                      €320.00
+    Assets:Bank                          $-348.00
+
+; --- Expense with multiple currencies on same account over time
+2026-03-10 * Amazon UK
+    Expenses:Shopping                    £45.00
+    Assets:Bank                          $-57.00
+
+2026-03-15 * Amazon US
+    Expenses:Shopping                    $62.00
+    Assets:Bank
+
+; --- Income from multiple sources in different currencies
+2026-04-01 * Salary USD
+    Assets:Bank                          $4,200.00
+    Income:Salary
+
+2026-04-02 * Dividend EUR
+    Assets:Bank                          €150.00
+    Income:Dividends
+
+; --- Unit cost (per-share) annotation
+2026-04-15 * Sell AAPL with unit cost
+    Assets:Bank                          $1,820.00
+    Assets:Investments:AAPL              -10 AAPL @ $182.00


### PR DESCRIPTION
## Summary
Adds US-format companion examples to the existing EU-only set in `examples/`. A US user opening the repo previously saw only `€` and might assume the app didn't fit their workflow — this fills that onboarding gap.

## New files
- **`examples/hledger-simple-us/main.journal`** (372 lines, ~80 transactions)
  - `$` commodity, left-side, no space
  - US number format: `$1,234.56` (comma thousands, dot decimal)
  - CapitalCase account names: `Assets:Checking`, `Expenses:Food:Groceries`
  - Same structure as `hledger-simple/main.journal`: 4 months of realistic transactions (Jan-Apr 2026)
  - Bi-weekly paychecks (typical US pattern), realistic merchants (Trader Joe's, Whole Foods, Costco, Comcast, AT&T, Planet Fitness, PG&E, etc.)
  - Edge cases at the end: posting comments, balance assertion, foreign currency mix (EUR + GBP)

- **`examples/multicommodity-us.journal`** (52 lines)
  - US-base multi-commodity stress test
  - `$` + AAPL/SPY ETFs as named commodities
  - Both `@@` total-cost and `@` unit-cost annotations
  - Multi-currency wallet accumulation (USD + EUR)
  - Foreign expenses (Paris hotel in EUR, Amazon UK in GBP)

## Validation
Both files validate cleanly:
```
$ hledger --no-conf -f examples/hledger-simple-us/main.journal check
$ hledger --no-conf -f examples/multicommodity-us.journal check
```

Note: the balance assertion in `hledger-simple-us` was iteratively corrected against the real running balance hledger calculated, so it's guaranteed to remain valid as long as the transactions above it don't change.

## README update
The "Examples" table gained a `Format` column distinguishing EU vs US for each example. New table:

| Example | Format | Description |
|---|---|---|
| `hledger-simple/` | EU (`€1.234,56`) | Single-file EU demo |
| `hledger-simple-us/` | US (`$1,234.56`) | Single-file US demo (new) |
| `hledger-multi-file/` | EU | Multi-file EU with glob routing |
| `multicommodity.journal` | EU base | Multi-currency edge cases (EUR + ETFs) |
| `multicommodity-us.journal` | US base | Multi-currency edge cases (USD + AAPL/SPY) (new) |
| `csv-import/` | mixed | CSV import wizard fixtures |

## What is intentionally NOT in this PR
- Rename of `hledger-simple/` to `hledger-simple-eu/` — `examples/` is the standard convention; renaming would break external links and add no disambiguation value
- US version of `hledger-multi-file/` — marginal value over the simple US example
- UK / CHF / INR examples — niche cases, separate issue if ever needed
- Any change to `csv-import/` — already locale-neutral

## Test plan
- [ ] CI green (the test suite is independent of these example files)
- [ ] After merge: rendered README shows both EU and US examples in the table

Closes #127