### PR TITLE
refactor: rename CsvPreviewTab files + align preview tables (#93)

### DIFF
--- a/hledger-macos/Views/CsvImport/CsvImportSheet.swift
+++ b/hledger-macos/Views/CsvImport/CsvImportSheet.swift
@@ -93,7 +93,7 @@ struct CsvImportSheet: View {
                 noFileView
             } else {
                 TabView(selection: $selectedTab) {
-                    CsvPreviewTab(
+                    CsvRawPreviewTab(
                         csvContent: csvContent,
                         config: $config,
                         rulesFileURL: $rulesFileURL,
@@ -112,7 +112,7 @@ struct CsvImportSheet: View {
                     .tabItem { Label("2. Rules Editor", systemImage: "doc.text") }
                     .tag(1)
 
-                    CsvImportPreviewTab(
+                    CsvTransactionPreviewTab(
                         previewTransactions: $previewTransactions,
                         isLoading: isParsing,
                         errorMessage: parseError

--- a/hledger-macos/Views/CsvImport/CsvRawPreviewTab.swift
+++ b/hledger-macos/Views/CsvImport/CsvRawPreviewTab.swift
@@ -82,7 +82,8 @@ struct CsvRawPreviewTab: View {
 
                 Divider()
 
-                // CSV table
+                // CSV table — fixed-width columns with zebra striping for
+                // readability, framed in a rounded macOS-style container.
                 if previewRows.isEmpty {
                     Text("No data to preview.")
                         .foregroundStyle(.secondary)
@@ -94,32 +95,39 @@ struct CsvRawPreviewTab: View {
                                     ForEach(firstRow.indices, id: \.self) { col in
                                         Text(firstRow[col].trimmingCharacters(in: .whitespaces))
                                             .font(.caption.weight(.semibold))
+                                            .foregroundStyle(.secondary)
                                             .frame(width: columnWidth, alignment: .leading)
                                             .lineLimit(1)
-                                            .padding(.vertical, 4)
-                                            .padding(.horizontal, 6)
+                                            .padding(.vertical, 6)
+                                            .padding(.horizontal, 8)
                                     }
                                 }
-                                .background(Color.accentColor.opacity(0.1))
+                                .background(Color.secondary.opacity(0.08))
 
                                 Divider()
                             }
 
-                            ForEach(Array(previewRows.dropFirst().enumerated()), id: \.offset) { _, row in
+                            ForEach(Array(previewRows.dropFirst().enumerated()), id: \.offset) { offset, row in
                                 HStack(spacing: 0) {
                                     ForEach(row.indices, id: \.self) { col in
                                         Text(row[col].trimmingCharacters(in: .whitespaces))
-                                            .font(.caption.monospaced())
+                                            .font(.system(.caption, design: .monospaced))
                                             .frame(width: columnWidth, alignment: .leading)
                                             .lineLimit(1)
-                                            .padding(.vertical, 3)
-                                            .padding(.horizontal, 6)
+                                            .padding(.vertical, 4)
+                                            .padding(.horizontal, 8)
                                     }
                                 }
+                                .background(offset.isMultiple(of: 2) ? Color.clear : Color.secondary.opacity(0.04))
                             }
                         }
                     }
-                    .border(Color.secondary.opacity(0.2))
+                    .background(Color(nsColor: .controlBackgroundColor))
+                    .clipShape(RoundedRectangle(cornerRadius: 6))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 6)
+                            .strokeBorder(Color.secondary.opacity(0.2), lineWidth: 1)
+                    )
                 }
             }
             .padding(16)

--- a/hledger-macos/Views/CsvImport/CsvRawPreviewTab.swift
+++ b/hledger-macos/Views/CsvImport/CsvRawPreviewTab.swift
@@ -5,7 +5,7 @@
 
 import SwiftUI
 
-struct CsvPreviewTab: View {
+struct CsvRawPreviewTab: View {
     let csvContent: String
     @Binding var config: CsvRulesConfig
     @Binding var rulesFileURL: URL?

--- a/hledger-macos/Views/CsvImport/CsvTransactionPreviewTab.swift
+++ b/hledger-macos/Views/CsvImport/CsvTransactionPreviewTab.swift
@@ -134,10 +134,12 @@ struct CsvTransactionPreviewTab: View {
                 .font(.caption)
                 .foregroundStyle(.secondary)
                 .lineLimit(1)
-                .frame(width: 160, alignment: .leading)
+                .truncationMode(.head)
+                .frame(width: 180, alignment: .trailing)
 
             Text(txn.amount)
                 .font(.system(.callout, design: .monospaced))
+                .frame(width: 110, alignment: .trailing)
         }
         .padding(.vertical, ListMetrics.rowPadding)
     }

--- a/hledger-macos/Views/CsvImport/CsvTransactionPreviewTab.swift
+++ b/hledger-macos/Views/CsvImport/CsvTransactionPreviewTab.swift
@@ -6,7 +6,7 @@
 
 import SwiftUI
 
-struct CsvImportPreviewTab: View {
+struct CsvTransactionPreviewTab: View {
     @Binding var previewTransactions: [CsvPreviewTransaction]
     let isLoading: Bool
     let errorMessage: String?

--- a/hledger-macos/Views/CsvImport/CsvTransactionPreviewTab.swift
+++ b/hledger-macos/Views/CsvImport/CsvTransactionPreviewTab.swift
@@ -87,14 +87,19 @@ struct CsvTransactionPreviewTab: View {
 
                 Divider()
 
-                // Transaction list
-                ScrollView {
-                    LazyVStack(spacing: 0) {
-                        ForEach(previewTransactions.indices, id: \.self) { index in
-                            transactionRow(index: index)
-                        }
+                // Transaction list — native List for alternating rows and macOS look,
+                // matching TransactionsView and AccountsView.
+                List {
+                    ForEach(previewTransactions.indices, id: \.self) { index in
+                        transactionRow(index: index)
+                            .listRowBackground(
+                                previewTransactions[index].isDuplicate
+                                    ? Color.orange.opacity(0.08)
+                                    : Color.clear
+                            )
                     }
                 }
+                .listStyle(.inset)
             }
         }
     }
@@ -102,23 +107,28 @@ struct CsvTransactionPreviewTab: View {
     @ViewBuilder
     private func transactionRow(index: Int) -> some View {
         let txn = previewTransactions[index]
-        HStack(spacing: 8) {
+        HStack(spacing: 12) {
             Toggle("", isOn: $previewTransactions[index].isSelected)
                 .labelsHidden()
-                .frame(width: 20)
+                .frame(width: 18)
 
             Text(txn.date)
-                .font(.callout.monospaced())
-                .frame(width: 90, alignment: .leading)
+                .font(.system(.callout, design: .monospaced))
+                .foregroundStyle(.secondary)
 
             Text(txn.description)
                 .font(.callout)
                 .lineLimit(1)
                 .frame(maxWidth: .infinity, alignment: .leading)
 
-            Text(txn.amount)
-                .font(.callout.monospaced())
-                .frame(width: 110, alignment: .trailing)
+            if txn.isDuplicate {
+                Text("duplicate")
+                    .font(.caption2)
+                    .foregroundStyle(.orange)
+                    .padding(.horizontal, 6)
+                    .padding(.vertical, 2)
+                    .background(Color.orange.opacity(0.15), in: RoundedRectangle(cornerRadius: 4))
+            }
 
             Text(txn.account2.isEmpty ? txn.account1 : txn.account2)
                 .font(.caption)
@@ -126,18 +136,9 @@ struct CsvTransactionPreviewTab: View {
                 .lineLimit(1)
                 .frame(width: 160, alignment: .leading)
 
-            if txn.isDuplicate {
-                Text("duplicate")
-                    .font(.caption2)
-                    .foregroundStyle(.orange)
-                    .frame(width: 55)
-            } else {
-                Spacer()
-                    .frame(width: 55)
-            }
+            Text(txn.amount)
+                .font(.system(.callout, design: .monospaced))
         }
-        .padding(.horizontal, 16)
-        .padding(.vertical, 4)
-        .background(txn.isDuplicate ? Color.orange.opacity(0.06) : Color.clear)
+        .padding(.vertical, ListMetrics.rowPadding)
     }
 }


### PR DESCRIPTION
## Summary
- Rename `CsvPreviewTab` → `CsvRawPreviewTab` (Tab 1: raw CSV preview)
- Rename `CsvImportPreviewTab` → `CsvTransactionPreviewTab` (Tab 3: parsed transactions)
- Update the two callsites in `CsvImportSheet`
- **Tab 3**: replace the custom `LazyVStack` inside a `ScrollView` with a native `List` + `.listStyle(.inset)` so the parsed-transaction preview inherits alternating rows, hover, and the standard macOS row chrome from `TransactionsView` / `AccountsView`. The duplicate-row tint moves from a manual `.background` to `listRowBackground`, and the row adopts `ListMetrics.rowPadding` + 12pt spacing to match `TransactionRowView`. The "duplicate" indicator becomes a subtle pill in the flow instead of a fixed-width trailing column.
- **Tab 1**: the raw CSV grid keeps its hand-rolled HStack layout (true 2D dynamic-column data — `SwiftUI.Table` does not fit dynamic columns), but gains zebra striping on data rows, slightly more breathing room per cell, and a rounded macOS-style container (`controlBackgroundColor` fill + subtle separator stroke).

The file headers already document each tab's wizard step, so no header changes are needed.

Closes #93

## Test plan
- [x] Build succeeds
- [x] All 326 unit tests pass
- [ ] Manual: open the CSV Import wizard
  - Tab 1 → verify the raw CSV table has zebra striping and the rounded container
  - Tab 3 → verify the parsed-transaction list looks like Transactions/Accounts (alternating rows, hover), duplicates are tinted via the row background, and the duplicate pill renders inline