### PR TITLE
refactor: extract PeriodNavigator component (#90)

### DIFF
--- a/hledger-macos/Views/Budget/BudgetView.swift
+++ b/hledger-macos/Views/Budget/BudgetView.swift
@@ -34,27 +34,11 @@ struct BudgetView: View {
 
     var body: some View {
         VStack(spacing: 0) {
-            // Period navigator
-            HStack {
-                Button(action: { previousMonth() }) {
-                    Image(systemName: "chevron.left").font(.title3)
-                }
-                .buttonStyle(.borderless)
-                .keyboardShortcut(.leftArrow, modifiers: [])
-
-                Spacer()
-                Text(periodLabel).font(.title2.bold())
-                Spacer()
-
-                Button(action: { nextMonth() }) {
-                    Image(systemName: "chevron.right").font(.title3)
-                }
-                .buttonStyle(.borderless)
-                .keyboardShortcut(.rightArrow, modifiers: [])
-            }
-            .padding(.horizontal, 16)
-            .padding(.top, 12)
-            .padding(.bottom, 16)
+            PeriodNavigator(
+                label: periodLabel,
+                onPrevious: { previousMonth() },
+                onNext: { nextMonth() }
+            )
 
             Divider()
 

--- a/hledger-macos/Views/Shared/PeriodNavigator.swift
+++ b/hledger-macos/Views/Shared/PeriodNavigator.swift
@@ -1,0 +1,38 @@
+/// Reusable month / period navigator with previous-next chevrons.
+/// Used by TransactionsView and BudgetView.
+
+import SwiftUI
+
+struct PeriodNavigator: View {
+    let label: String
+    let onPrevious: () -> Void
+    let onNext: () -> Void
+
+    var body: some View {
+        HStack {
+            Button(action: onPrevious) {
+                Image(systemName: "chevron.left")
+                    .font(.title3)
+            }
+            .buttonStyle(.borderless)
+            .keyboardShortcut(.leftArrow, modifiers: [])
+
+            Spacer()
+
+            Text(label)
+                .font(.title2.bold())
+
+            Spacer()
+
+            Button(action: onNext) {
+                Image(systemName: "chevron.right")
+                    .font(.title3)
+            }
+            .buttonStyle(.borderless)
+            .keyboardShortcut(.rightArrow, modifiers: [])
+        }
+        .padding(.horizontal, 16)
+        .padding(.top, 12)
+        .padding(.bottom, 16)
+    }
+}

--- a/hledger-macos/Views/Transactions/TransactionsView.swift
+++ b/hledger-macos/Views/Transactions/TransactionsView.swift
@@ -16,32 +16,11 @@ struct TransactionsView: View {
     var body: some View {
         @Bindable var state = appState
         VStack(spacing: 0) {
-            // Period navigator
-            HStack {
-                Button(action: { appState.previousMonth() }) {
-                    Image(systemName: "chevron.left")
-                        .font(.title3)
-                }
-                .buttonStyle(.borderless)
-                .keyboardShortcut(.leftArrow, modifiers: [])
-
-                Spacer()
-
-                Text(appState.periodLabel)
-                    .font(.title2.bold())
-
-                Spacer()
-
-                Button(action: { appState.nextMonth() }) {
-                    Image(systemName: "chevron.right")
-                        .font(.title3)
-                }
-                .buttonStyle(.borderless)
-                .keyboardShortcut(.rightArrow, modifiers: [])
-            }
-            .padding(.horizontal, 16)
-            .padding(.top, 12)
-            .padding(.bottom, 16)
+            PeriodNavigator(
+                label: appState.periodLabel,
+                onPrevious: { appState.previousMonth() },
+                onNext: { appState.nextMonth() }
+            )
 
             // Income / Expenses cards (always visible)
             HStack(spacing: 16) {


### PR DESCRIPTION
## Summary
- Add `Views/Shared/PeriodNavigator.swift` with the chevron-left / label / chevron-right month navigator and its left/right arrow keyboard shortcuts
- Use it in `TransactionsView` and `BudgetView`, which both duplicated the same HStack inline
- The padding (`.horizontal 16`, `.top 12`, `.bottom 16`) is moved into the component since both call sites used the same values

Closes #90

## Test plan
- [x] Build succeeds
- [x] All 326 unit tests pass
- [ ] Manual: open Transactions and Budget views, verify the period navigator and left/right arrow keyboard shortcuts still work