### PR TITLE
refactor: extract LoadingOverlay component (#87)

### DIFF
--- a/hledger-macos/Views/Accounts/AccountTransactionsSheet.swift
+++ b/hledger-macos/Views/Accounts/AccountTransactionsSheet.swift
@@ -90,9 +90,7 @@ struct AccountTransactionsSheet: View {
     @ViewBuilder
     private var content: some View {
         if isLoading {
-            Spacer()
-            ProgressView("Loading transactions...")
-            Spacer()
+            LoadingOverlay(message: "Loading transactions...")
         } else if let error = errorMessage {
             Spacer()
             ContentUnavailableView("Error", systemImage: "exclamationmark.triangle",

--- a/hledger-macos/Views/Accounts/AccountsView.swift
+++ b/hledger-macos/Views/Accounts/AccountsView.swift
@@ -27,9 +27,7 @@ struct AccountsView: View {
     var body: some View {
         VStack(spacing: 0) {
             if isLoading {
-                Spacer()
-                ProgressView("Loading accounts...")
-                Spacer()
+                LoadingOverlay(message: "Loading accounts...")
             } else if viewMode == "flat" {
                 flatView
             } else {

--- a/hledger-macos/Views/Budget/BudgetView.swift
+++ b/hledger-macos/Views/Budget/BudgetView.swift
@@ -60,9 +60,7 @@ struct BudgetView: View {
 
             // Content
             if isLoading {
-                Spacer()
-                ProgressView("Loading budget...")
-                Spacer()
+                LoadingOverlay(message: "Loading budget...")
             } else if rules.isEmpty {
                 Spacer()
                 ContentUnavailableView(

--- a/hledger-macos/Views/CsvImport/CsvImportPreviewTab.swift
+++ b/hledger-macos/Views/CsvImport/CsvImportPreviewTab.swift
@@ -18,12 +18,7 @@ struct CsvImportPreviewTab: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
             if isLoading {
-                VStack {
-                    Spacer()
-                    ProgressView("Parsing CSV with hledger...")
-                    Spacer()
-                }
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                LoadingOverlay(message: "Parsing CSV with hledger...")
             } else if let error = errorMessage {
                 VStack(spacing: 8) {
                     Spacer()

--- a/hledger-macos/Views/Recurring/RecurringView.swift
+++ b/hledger-macos/Views/Recurring/RecurringView.swift
@@ -21,9 +21,7 @@ struct RecurringView: View {
     var body: some View {
         VStack(spacing: 0) {
             if isLoading {
-                Spacer()
-                ProgressView("Loading rules...")
-                Spacer()
+                LoadingOverlay(message: "Loading rules...")
             } else if rules.isEmpty {
                 Spacer()
                 ContentUnavailableView(

--- a/hledger-macos/Views/Reports/ReportsView.swift
+++ b/hledger-macos/Views/Reports/ReportsView.swift
@@ -37,9 +37,7 @@ struct ReportsView: View {
     var body: some View {
         VStack(spacing: 0) {
             if isLoading {
-                Spacer()
-                ProgressView("Loading report...")
-                Spacer()
+                LoadingOverlay(message: "Loading report...")
             } else if let data = reportData, !data.rows.isEmpty {
                 reportContent(data)
             } else {

--- a/hledger-macos/Views/Shared/LoadingOverlay.swift
+++ b/hledger-macos/Views/Shared/LoadingOverlay.swift
@@ -1,0 +1,17 @@
+/// Centered loading indicator with a message that fills available space.
+/// Replaces the Spacer / ProgressView / Spacer pattern duplicated across views.
+
+import SwiftUI
+
+struct LoadingOverlay: View {
+    let message: String
+
+    var body: some View {
+        VStack {
+            Spacer()
+            ProgressView(message)
+            Spacer()
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+}

--- a/hledger-macos/Views/Transactions/TransactionsView.swift
+++ b/hledger-macos/Views/Transactions/TransactionsView.swift
@@ -60,9 +60,7 @@ struct TransactionsView: View {
 
             // Transaction list
             if appState.isLoading {
-                Spacer()
-                ProgressView("Loading transactions...")
-                Spacer()
+                LoadingOverlay(message: "Loading transactions...")
             } else if appState.transactions.isEmpty {
                 Spacer()
                 ContentUnavailableView(


### PR DESCRIPTION
## Summary
- Add `Views/Shared/LoadingOverlay.swift` — a centered, full-frame `ProgressView(message)`
- Replace the duplicated `Spacer / ProgressView / Spacer` pattern in 7 sites:
  - `AccountsView`, `ReportsView`, `RecurringView`, `BudgetView`
  - `TransactionsView` (not in issue, identical)
  - `AccountTransactionsSheet` (not in issue, identical)
  - `CsvImportPreviewTab` (already wrapped in `VStack` + `frame`)

Net: −17 lines, single source of truth for the loading screen.

## Note on issue scope
The issue listed `TransactionFormView` as a 6th site, but that view has no loading state — only an `isSaving` guard inside the Save button. I touched the actual 7 sites that match the pattern instead.

Closes #87

## Test plan
- [x] Build succeeds
- [x] All 326 unit tests pass
- [ ] Manual: open Accounts, Reports, Recurring, Budget, Transactions, Account drill-down sheet, and the CSV import wizard → verify the loading screen still appears centered while data loads