### PR TITLE
refactor: replace hardcoded paddings with Theme.Spacing tokens (#88)

### DIFF
--- a/hledger-macos/Config/Theme.swift
+++ b/hledger-macos/Config/Theme.swift
@@ -6,12 +6,19 @@ enum Theme {
     // MARK: - Spacing
 
     enum Spacing {
+        static let xxs: CGFloat = 2
+        static let xxsPlus: CGFloat = 3
         static let xs: CGFloat = 4
+        static let xsPlus: CGFloat = 6
         static let sm: CGFloat = 8
+        static let smPlus: CGFloat = 10
         static let md: CGFloat = 12
+        static let mdPlus: CGFloat = 14
         static let lg: CGFloat = 16
         static let xl: CGFloat = 20
         static let xxl: CGFloat = 24
+        static let xxxl: CGFloat = 32
+        static let huge: CGFloat = 40
     }
 
     // MARK: - Corner Radius

--- a/hledger-macos/Views/Accounts/AccountTransactionsSheet.swift
+++ b/hledger-macos/Views/Accounts/AccountTransactionsSheet.swift
@@ -81,8 +81,8 @@ struct AccountTransactionsSheet: View {
             Button("Done") { dismiss() }
                 .keyboardShortcut(.escape, modifiers: [])
         }
-        .padding(.horizontal, 20)
-        .padding(.vertical, 14)
+        .padding(.horizontal, Theme.Spacing.xl)
+        .padding(.vertical, Theme.Spacing.mdPlus)
     }
 
     // MARK: - Content

--- a/hledger-macos/Views/Budget/BudgetFormView.swift
+++ b/hledger-macos/Views/Budget/BudgetFormView.swift
@@ -31,8 +31,8 @@ struct BudgetFormView: View {
                             .foregroundStyle(Color.accentColor)
                         Spacer()
                     }
-                    .padding(.top, 20)
-                    .padding(.bottom, 20)
+                    .padding(.top, Theme.Spacing.xl)
+                    .padding(.bottom, Theme.Spacing.xl)
 
                     // Fields
                     VStack(spacing: 14) {
@@ -54,7 +54,7 @@ struct BudgetFormView: View {
                                 .textFieldStyle(.roundedBorder)
                         }
                     }
-                    .padding(.horizontal, 24)
+                    .padding(.horizontal, Theme.Spacing.xxl)
                 }
             }
 
@@ -79,8 +79,8 @@ struct BudgetFormView: View {
                     .keyboardShortcut(.defaultAction)
                     .disabled(account.isEmpty || amount.isEmpty)
             }
-            .padding(.horizontal, 24)
-            .padding(.vertical, 12)
+            .padding(.horizontal, Theme.Spacing.xxl)
+            .padding(.vertical, Theme.Spacing.md)
         }
         .frame(width: 480, height: 300)
         .onAppear { prefill() }

--- a/hledger-macos/Views/CsvImport/ConditionalRuleFormView.swift
+++ b/hledger-macos/Views/CsvImport/ConditionalRuleFormView.swift
@@ -28,8 +28,8 @@ struct ConditionalRuleFormView: View {
                             .foregroundStyle(Color.accentColor)
                         Spacer()
                     }
-                    .padding(.top, 20)
-                    .padding(.bottom, 20)
+                    .padding(.top, Theme.Spacing.xl)
+                    .padding(.bottom, Theme.Spacing.xl)
 
                     VStack(spacing: 14) {
                         FormRow("Pattern:", labelWidth: 80) {
@@ -50,7 +50,7 @@ struct ConditionalRuleFormView: View {
                                 .textFieldStyle(.roundedBorder)
                         }
                     }
-                    .padding(.horizontal, 24)
+                    .padding(.horizontal, Theme.Spacing.xxl)
                 }
             }
 
@@ -74,8 +74,8 @@ struct ConditionalRuleFormView: View {
                     .keyboardShortcut(.defaultAction)
                     .disabled(pattern.isEmpty || account.isEmpty)
             }
-            .padding(.horizontal, 24)
-            .padding(.vertical, 12)
+            .padding(.horizontal, Theme.Spacing.xxl)
+            .padding(.vertical, Theme.Spacing.md)
         }
         .frame(width: 440, height: 280)
         .onAppear { prefill() }

--- a/hledger-macos/Views/CsvImport/CsvImportSheet.swift
+++ b/hledger-macos/Views/CsvImport/CsvImportSheet.swift
@@ -85,9 +85,9 @@ struct CsvImportSheet: View {
                     .font(.callout)
                 }
             }
-            .padding(.horizontal, 20)
-            .padding(.top, 16)
-            .padding(.bottom, 8)
+            .padding(.horizontal, Theme.Spacing.xl)
+            .padding(.top, Theme.Spacing.lg)
+            .padding(.bottom, Theme.Spacing.sm)
 
             if csvContent.isEmpty {
                 noFileView
@@ -157,8 +157,8 @@ struct CsvImportSheet: View {
                 .keyboardShortcut(.defaultAction)
                 .disabled(!isReadyToImport)
             }
-            .padding(.horizontal, 20)
-            .padding(.vertical, 12)
+            .padding(.horizontal, Theme.Spacing.xl)
+            .padding(.vertical, Theme.Spacing.md)
         }
         .frame(width: 760, height: 660)
         .task { await loadAutocompleteData() }

--- a/hledger-macos/Views/CsvImport/CsvRawPreviewTab.swift
+++ b/hledger-macos/Views/CsvImport/CsvRawPreviewTab.swift
@@ -98,8 +98,8 @@ struct CsvRawPreviewTab: View {
                                             .foregroundStyle(.secondary)
                                             .frame(width: columnWidth, alignment: .leading)
                                             .lineLimit(1)
-                                            .padding(.vertical, 6)
-                                            .padding(.horizontal, 8)
+                                            .padding(.vertical, Theme.Spacing.xsPlus)
+                                            .padding(.horizontal, Theme.Spacing.sm)
                                     }
                                 }
                                 .background(Color.secondary.opacity(0.08))
@@ -114,8 +114,8 @@ struct CsvRawPreviewTab: View {
                                             .font(.system(.caption, design: .monospaced))
                                             .frame(width: columnWidth, alignment: .leading)
                                             .lineLimit(1)
-                                            .padding(.vertical, 4)
-                                            .padding(.horizontal, 8)
+                                            .padding(.vertical, Theme.Spacing.xs)
+                                            .padding(.horizontal, Theme.Spacing.sm)
                                     }
                                 }
                                 .background(offset.isMultiple(of: 2) ? Color.clear : Color.secondary.opacity(0.04))
@@ -130,7 +130,7 @@ struct CsvRawPreviewTab: View {
                     )
                 }
             }
-            .padding(16)
+            .padding(Theme.Spacing.lg)
         }
         .onAppear { runAutoDetection() }
     }

--- a/hledger-macos/Views/CsvImport/CsvRulesEditorView.swift
+++ b/hledger-macos/Views/CsvImport/CsvRulesEditorView.swift
@@ -34,7 +34,7 @@ struct CsvRulesEditorView: View {
                 conditionalRulesSection
                 rawEditorSection
             }
-            .padding(20)
+            .padding(Theme.Spacing.xl)
         }
     }
 
@@ -62,14 +62,14 @@ struct CsvRulesEditorView: View {
                 }
                 .font(.caption.weight(.semibold))
                 .foregroundStyle(.secondary)
-                .padding(.horizontal, 8)
+                .padding(.horizontal, Theme.Spacing.sm)
 
                 ForEach(config.columnMappings.indices, id: \.self) { index in
                     columnMappingRow(index: index)
                 }
             }
         }
-        .padding(14)
+        .padding(Theme.Spacing.mdPlus)
         .background(.quaternary.opacity(0.3), in: RoundedRectangle(cornerRadius: 8))
     }
 
@@ -97,8 +97,8 @@ struct CsvRulesEditorView: View {
             .labelsHidden()
             .frame(minWidth: 140)
         }
-        .padding(.horizontal, 8)
-        .padding(.vertical, 2)
+        .padding(.horizontal, Theme.Spacing.sm)
+        .padding(.vertical, Theme.Spacing.xxs)
     }
 
     // MARK: - Settings
@@ -169,7 +169,7 @@ struct CsvRulesEditorView: View {
                 }
             }
         }
-        .padding(14)
+        .padding(Theme.Spacing.mdPlus)
         .background(.quaternary.opacity(0.3), in: RoundedRectangle(cornerRadius: 8))
     }
 
@@ -208,14 +208,14 @@ struct CsvRulesEditorView: View {
                 }
                 .font(.caption.weight(.semibold))
                 .foregroundStyle(.secondary)
-                .padding(.horizontal, 8)
+                .padding(.horizontal, Theme.Spacing.sm)
 
                 ForEach(config.conditionalRules) { rule in
                     conditionalRuleRow(rule)
                 }
             }
         }
-        .padding(14)
+        .padding(Theme.Spacing.mdPlus)
         .background(.quaternary.opacity(0.3), in: RoundedRectangle(cornerRadius: 8))
         .sheet(isPresented: $showingConditionalForm) {
             ConditionalRuleFormView(
@@ -263,10 +263,10 @@ struct CsvRulesEditorView: View {
                     .foregroundStyle(.red)
             }
             .buttonStyle(.plain)
-            .padding(.leading, 8)
+            .padding(.leading, Theme.Spacing.sm)
         }
-        .padding(.horizontal, 8)
-        .padding(.vertical, 3)
+        .padding(.horizontal, Theme.Spacing.sm)
+        .padding(.vertical, Theme.Spacing.xxsPlus)
     }
 
     // MARK: - Raw Editor
@@ -301,7 +301,7 @@ struct CsvRulesEditorView: View {
                     }
             }
         }
-        .padding(14)
+        .padding(Theme.Spacing.mdPlus)
         .background(.quaternary.opacity(0.3), in: RoundedRectangle(cornerRadius: 8))
         .onChange(of: showRawEditor) {
             if showRawEditor {

--- a/hledger-macos/Views/CsvImport/CsvTransactionPreviewTab.swift
+++ b/hledger-macos/Views/CsvImport/CsvTransactionPreviewTab.swift
@@ -81,9 +81,9 @@ struct CsvTransactionPreviewTab: View {
                     .disabled(duplicateCount == 0)
                 }
                 .font(.callout)
-                .padding(.horizontal, 16)
-                .padding(.top, 12)
-                .padding(.bottom, 8)
+                .padding(.horizontal, Theme.Spacing.lg)
+                .padding(.top, Theme.Spacing.md)
+                .padding(.bottom, Theme.Spacing.sm)
 
                 Divider()
 

--- a/hledger-macos/Views/CsvImport/RulesManagerSheet.swift
+++ b/hledger-macos/Views/CsvImport/RulesManagerSheet.swift
@@ -26,9 +26,9 @@ struct RulesManagerSheet: View {
                     .font(.title2.bold())
                 Spacer()
             }
-            .padding(.horizontal, 20)
-            .padding(.top, 16)
-            .padding(.bottom, 12)
+            .padding(.horizontal, Theme.Spacing.xl)
+            .padding(.top, Theme.Spacing.lg)
+            .padding(.bottom, Theme.Spacing.md)
 
             Divider()
 
@@ -49,7 +49,7 @@ struct RulesManagerSheet: View {
                     Spacer()
                 }
                 .frame(maxWidth: .infinity)
-                .padding(.horizontal, 20)
+                .padding(.horizontal, Theme.Spacing.xl)
             } else {
                 List(selection: $selectedRule) {
                     ForEach(rulesFiles) { info in
@@ -113,8 +113,8 @@ struct RulesManagerSheet: View {
                 Button("Done") { dismiss() }
                     .keyboardShortcut(.cancelAction)
             }
-            .padding(.horizontal, 20)
-            .padding(.vertical, 12)
+            .padding(.horizontal, Theme.Spacing.xl)
+            .padding(.vertical, Theme.Spacing.md)
         }
         .frame(width: 560, height: 420)
         .task { await loadData() }
@@ -207,9 +207,9 @@ private struct RulesEditorSheet: View {
                     .font(.headline)
                 Spacer()
             }
-            .padding(.horizontal, 20)
-            .padding(.top, 16)
-            .padding(.bottom, 8)
+            .padding(.horizontal, Theme.Spacing.xl)
+            .padding(.top, Theme.Spacing.lg)
+            .padding(.bottom, Theme.Spacing.sm)
 
             CsvRulesEditorView(
                 config: $config,
@@ -233,8 +233,8 @@ private struct RulesEditorSheet: View {
                 .buttonStyle(.borderedProminent)
                 .keyboardShortcut(.defaultAction)
             }
-            .padding(.horizontal, 20)
-            .padding(.vertical, 12)
+            .padding(.horizontal, Theme.Spacing.xl)
+            .padding(.vertical, Theme.Spacing.md)
         }
         .frame(width: 640, height: 580)
     }

--- a/hledger-macos/Views/MainWindow/CommandLogView.swift
+++ b/hledger-macos/Views/MainWindow/CommandLogView.swift
@@ -51,8 +51,8 @@ struct CommandLogView: View {
                     Spacer()
                 }
             }
-            .padding(.horizontal, 16)
-            .padding(.vertical, 12)
+            .padding(.horizontal, Theme.Spacing.lg)
+            .padding(.vertical, Theme.Spacing.md)
 
             Divider()
 
@@ -80,7 +80,7 @@ struct CommandLogView: View {
                                 .truncationMode(.middle)
                         }
                         .tag(entry)
-                        .padding(.vertical, 2)
+                        .padding(.vertical, Theme.Spacing.xxs)
                     }
                     .listStyle(.inset)
                     .frame(minWidth: 400)
@@ -108,8 +108,8 @@ struct CommandLogView: View {
                 Button("Done") { dismiss() }
                     .keyboardShortcut(.defaultAction)
             }
-            .padding(.horizontal, 16)
-            .padding(.vertical, 10)
+            .padding(.horizontal, Theme.Spacing.lg)
+            .padding(.vertical, Theme.Spacing.smPlus)
         }
         .frame(width: 900, height: 500)
     }
@@ -162,7 +162,7 @@ struct CommandLogView: View {
                     detailSection("stdout", String(entry.stdout.prefix(2000)))
                 }
             }
-            .padding(16)
+            .padding(Theme.Spacing.lg)
         }
     }
 

--- a/hledger-macos/Views/MainWindow/SummaryView.swift
+++ b/hledger-macos/Views/MainWindow/SummaryView.swift
@@ -37,9 +37,9 @@ struct SummaryView: View {
                         .frame(maxWidth: .infinity)
                 }
             }
-            .padding(.horizontal, 24)
-            .padding(.top, 16)
-            .padding(.bottom, 24)
+            .padding(.horizontal, Theme.Spacing.xxl)
+            .padding(.top, Theme.Spacing.lg)
+            .padding(.bottom, Theme.Spacing.xxl)
         }
         .navigationTitle("Summary")
         .toolbar {
@@ -106,14 +106,14 @@ struct SummaryView: View {
                     modeB: .byName
                 )
             }
-            .padding(.bottom, 2)
+            .padding(.bottom, Theme.Spacing.xxs)
 
             if items.isEmpty {
                 Text("No data for this period")
                     .font(.caption)
                     .foregroundStyle(.tertiary)
                     .frame(maxWidth: .infinity, alignment: .leading)
-                    .padding(.vertical, 8)
+                    .padding(.vertical, Theme.Spacing.sm)
             }
 
             let total = items.reduce(Decimal(0)) { $0 + $1.1 }
@@ -136,7 +136,7 @@ struct SummaryView: View {
                 .frame(height: 20)
             }
         }
-        .padding(16)
+        .padding(Theme.Spacing.lg)
         .background(.quaternary.opacity(0.3), in: RoundedRectangle(cornerRadius: 10))
     }
 
@@ -161,7 +161,7 @@ struct SummaryView: View {
                     }
                 }
             }
-            .padding(.bottom, 2)
+            .padding(.bottom, Theme.Spacing.xxs)
 
             // Header
             portfolioRow(
@@ -192,7 +192,7 @@ struct SummaryView: View {
                 Text("Configure price tickers in Settings > Investments to see market values.")
                     .font(.caption)
                     .foregroundStyle(.tertiary)
-                    .padding(.top, 4)
+                    .padding(.top, Theme.Spacing.xs)
             } else if !appState.failedPriceTickers.isEmpty {
                 Label(
                     "Could not fetch prices for: \(appState.failedPriceTickers.sorted().joined(separator: ", "))",
@@ -200,15 +200,15 @@ struct SummaryView: View {
                 )
                 .font(.caption)
                 .foregroundStyle(.orange)
-                .padding(.top, 4)
+                .padding(.top, Theme.Spacing.xs)
             } else if showMarketColumns {
                 Label("Prices via Yahoo Finance (delayed)", systemImage: "info.circle")
                     .font(.caption)
                     .foregroundStyle(.tertiary)
-                    .padding(.top, 4)
+                    .padding(.top, Theme.Spacing.xs)
             }
         }
-        .padding(16)
+        .padding(Theme.Spacing.lg)
         .background(.quaternary.opacity(0.3), in: RoundedRectangle(cornerRadius: 10))
     }
 

--- a/hledger-macos/Views/Onboarding/OnboardingView.swift
+++ b/hledger-macos/Views/Onboarding/OnboardingView.swift
@@ -21,18 +21,18 @@ struct OnboardingView: View {
             Image(systemName: "text.book.closed")
                 .font(.system(size: 56))
                 .foregroundStyle(Color.accentColor)
-                .padding(.bottom, 20)
+                .padding(.bottom, Theme.Spacing.xl)
 
             // Title
             Text("Welcome to hledger for Mac")
                 .font(.largeTitle.bold())
-                .padding(.bottom, 6)
+                .padding(.bottom, Theme.Spacing.xsPlus)
 
             // Subtitle
             Text("A macOS companion for plain text accounting")
                 .font(.body)
                 .foregroundStyle(.secondary)
-                .padding(.bottom, 32)
+                .padding(.bottom, Theme.Spacing.xxxl)
 
             // Status row
             HStack(spacing: 10) {
@@ -57,11 +57,11 @@ struct OnboardingView: View {
 
                 Spacer()
             }
-            .padding(.horizontal, 20)
-            .padding(.vertical, 12)
+            .padding(.horizontal, Theme.Spacing.xl)
+            .padding(.vertical, Theme.Spacing.md)
             .background(.quaternary.opacity(0.4), in: RoundedRectangle(cornerRadius: 8))
             .frame(maxWidth: 440)
-            .padding(.bottom, 12)
+            .padding(.bottom, Theme.Spacing.md)
 
             // Advanced settings
             VStack(spacing: 0) {
@@ -82,16 +82,16 @@ struct OnboardingView: View {
                     .contentShape(Rectangle())
                 }
                 .buttonStyle(.plain)
-                .padding(.horizontal, 20)
-                .padding(.vertical, 10)
+                .padding(.horizontal, Theme.Spacing.xl)
+                .padding(.vertical, Theme.Spacing.smPlus)
 
                 if showAdvanced {
                     VStack(spacing: 10) {
                         LabeledField(label: "hledger path", text: $customHledgerPath, placeholder: "/opt/homebrew/bin/hledger")
                         LabeledField(label: "Journal file", text: $customJournalPath, placeholder: "~/.hledger.journal")
                     }
-                    .padding(.horizontal, 20)
-                    .padding(.bottom, 12)
+                    .padding(.horizontal, Theme.Spacing.xl)
+                    .padding(.bottom, Theme.Spacing.md)
                     .transition(.opacity.combined(with: .move(edge: .top)))
                 }
             }
@@ -122,19 +122,19 @@ struct OnboardingView: View {
                 .buttonStyle(.borderedProminent)
                 .disabled(isScanning || !isFound)
             }
-            .padding(.bottom, 8)
+            .padding(.bottom, Theme.Spacing.sm)
 
             if let error = appState.errorMessage {
                 Text(error)
                     .foregroundStyle(.red)
                     .font(.caption)
-                    .padding(.bottom, 4)
+                    .padding(.bottom, Theme.Spacing.xs)
             }
 
             Spacer()
                 .frame(height: 40)
         }
-        .padding(.horizontal, 40)
+        .padding(.horizontal, Theme.Spacing.huge)
         .frame(minWidth: 560, minHeight: 480)
         .onAppear {
             customHledgerPath = appState.config.hledgerBinaryPath

--- a/hledger-macos/Views/Recurring/RecurringFormView.swift
+++ b/hledger-macos/Views/Recurring/RecurringFormView.swift
@@ -37,8 +37,8 @@ struct RecurringFormView: View {
                             .foregroundStyle(Color.accentColor)
                         Spacer()
                     }
-                    .padding(.top, 20)
-                    .padding(.bottom, 20)
+                    .padding(.top, Theme.Spacing.xl)
+                    .padding(.bottom, Theme.Spacing.xl)
 
                     // Fields
                     VStack(spacing: 14) {
@@ -68,11 +68,11 @@ struct RecurringFormView: View {
                             DateInputField(year: $endYear, month: $endMonth, day: $endDay, optional: true)
                         }
                     }
-                    .padding(.horizontal, 24)
+                    .padding(.horizontal, Theme.Spacing.xxl)
 
                     // Postings
                     VStack(alignment: .leading, spacing: 8) {
-                        Divider().padding(.vertical, 12)
+                        Divider().padding(.vertical, Theme.Spacing.md)
 
                         Text("Postings")
                             .font(.subheadline.bold())
@@ -80,7 +80,7 @@ struct RecurringFormView: View {
                         Text("Leave one amount blank for auto-balance.")
                             .font(.caption)
                             .foregroundStyle(.secondary)
-                            .padding(.bottom, 8)
+                            .padding(.bottom, Theme.Spacing.sm)
 
                         ForEach(Array(postingRows.enumerated()), id: \.element.id) { index, _ in
                             PostingRowField(
@@ -100,10 +100,10 @@ struct RecurringFormView: View {
                             Label("Add Posting", systemImage: "plus")
                         }
                         .controlSize(.small)
-                        .padding(.top, 4)
+                        .padding(.top, Theme.Spacing.xs)
                     }
-                    .padding(.horizontal, 24)
-                    .padding(.bottom, 16)
+                    .padding(.horizontal, Theme.Spacing.xxl)
+                    .padding(.bottom, Theme.Spacing.lg)
                 }
             }
 
@@ -128,8 +128,8 @@ struct RecurringFormView: View {
                     .keyboardShortcut(.defaultAction)
                     .disabled(description.isEmpty || startYear.isEmpty)
             }
-            .padding(.horizontal, 24)
-            .padding(.vertical, 12)
+            .padding(.horizontal, Theme.Spacing.xxl)
+            .padding(.vertical, Theme.Spacing.md)
         }
         .frame(width: 560, height: 520)
         .onAppear { prefill() }

--- a/hledger-macos/Views/Recurring/RecurringView.swift
+++ b/hledger-macos/Views/Recurring/RecurringView.swift
@@ -248,8 +248,8 @@ struct RecurringRuleRow: View {
             // Period badge
             Text(rule.periodExpr)
                 .font(.caption.weight(.medium))
-                .padding(.horizontal, 8)
-                .padding(.vertical, 3)
+                .padding(.horizontal, Theme.Spacing.sm)
+                .padding(.vertical, Theme.Spacing.xxsPlus)
                 .background(Color.accentColor.opacity(0.15), in: RoundedRectangle(cornerRadius: 4))
 
             // Description

--- a/hledger-macos/Views/Reports/ReportChartOverlay.swift
+++ b/hledger-macos/Views/Reports/ReportChartOverlay.swift
@@ -24,9 +24,9 @@ struct ReportChartOverlay: View {
                 .buttonStyle(.plain)
                 .keyboardShortcut(.cancelAction)
             }
-            .padding(.horizontal, 24)
-            .padding(.top, 20)
-            .padding(.bottom, 12)
+            .padding(.horizontal, Theme.Spacing.xxl)
+            .padding(.top, Theme.Spacing.xl)
+            .padding(.bottom, Theme.Spacing.md)
 
             // Chart
             Group {
@@ -39,8 +39,8 @@ struct ReportChartOverlay: View {
                     singleSeriesChart(title: "Cash Flow")
                 }
             }
-            .padding(.horizontal, 24)
-            .padding(.bottom, 24)
+            .padding(.horizontal, Theme.Spacing.xxl)
+            .padding(.bottom, Theme.Spacing.xxl)
         }
         .frame(width: 860, height: 560)
         .background(.ultraThinMaterial)

--- a/hledger-macos/Views/Reports/ReportsView.swift
+++ b/hledger-macos/Views/Reports/ReportsView.swift
@@ -159,7 +159,7 @@ struct ReportsView: View {
                                 .foregroundStyle(.tertiary)
                         }
                         .buttonStyle(.plain)
-                        .padding(.trailing, 6)
+                        .padding(.trailing, Theme.Spacing.xsPlus)
                     }
 
                     ReportRowView(

--- a/hledger-macos/Views/Settings/SettingsView.swift
+++ b/hledger-macos/Views/Settings/SettingsView.swift
@@ -318,7 +318,7 @@ struct SettingsView: View {
                 .font(.caption)
                 .foregroundStyle(.tertiary)
 
-            Divider().frame(width: 180).padding(.vertical, 4)
+            Divider().frame(width: 180).padding(.vertical, Theme.Spacing.xs)
 
             HStack(spacing: 16) {
                 Link("GitHub", destination: URL(string: "https://github.com/thesmokinator/hledger-macos")!)
@@ -350,8 +350,8 @@ struct SettingsView: View {
                     .buttonStyle(.borderedProminent)
                     .keyboardShortcut(.defaultAction)
             }
-            .padding(.horizontal, 20)
-            .padding(.vertical, 10)
+            .padding(.horizontal, Theme.Spacing.xl)
+            .padding(.vertical, Theme.Spacing.smPlus)
         }
     }
 

--- a/hledger-macos/Views/Shared/BreakdownBar.swift
+++ b/hledger-macos/Views/Shared/BreakdownBar.swift
@@ -62,7 +62,7 @@ struct BreakdownRow: View {
                     .popover(isPresented: $showingMultiCurrencyInfo) {
                         Text("This account has balances in multiple currencies. Only the default currency is shown here. See Accounts for full details.")
                             .font(.callout)
-                            .padding(12)
+                            .padding(Theme.Spacing.md)
                             .frame(width: 280)
                     }
             }

--- a/hledger-macos/Views/Shared/FormRow.swift
+++ b/hledger-macos/Views/Shared/FormRow.swift
@@ -19,7 +19,7 @@ struct FormRow<Content: View>: View {
                 .font(.callout)
                 .foregroundStyle(.secondary)
                 .frame(width: labelWidth, alignment: .trailing)
-                .padding(.top, 6)
+                .padding(.top, Theme.Spacing.xsPlus)
             content
         }
     }

--- a/hledger-macos/Views/Shared/ListStyles.swift
+++ b/hledger-macos/Views/Shared/ListStyles.swift
@@ -21,7 +21,7 @@ struct AccountRow: View {
                         .foregroundStyle(.tertiary)
                 }
                 .buttonStyle(.plain)
-                .padding(.trailing, 6)
+                .padding(.trailing, Theme.Spacing.xsPlus)
             }
             Text(label)
                 .font(labelBold ? labelFont.bold() : labelFont)

--- a/hledger-macos/Views/Shared/PeriodNavigator.swift
+++ b/hledger-macos/Views/Shared/PeriodNavigator.swift
@@ -31,8 +31,8 @@ struct PeriodNavigator: View {
             .buttonStyle(.borderless)
             .keyboardShortcut(.rightArrow, modifiers: [])
         }
-        .padding(.horizontal, 16)
-        .padding(.top, 12)
-        .padding(.bottom, 16)
+        .padding(.horizontal, Theme.Spacing.lg)
+        .padding(.top, Theme.Spacing.md)
+        .padding(.bottom, Theme.Spacing.lg)
     }
 }

--- a/hledger-macos/Views/Shared/SummaryCard.swift
+++ b/hledger-macos/Views/Shared/SummaryCard.swift
@@ -44,8 +44,8 @@ struct SummaryCard: View {
                 .foregroundStyle(.secondary)
         }
         .frame(maxWidth: .infinity, minHeight: 100)
-        .padding(.vertical, 16)
-        .padding(.horizontal, 20)
+        .padding(.vertical, Theme.Spacing.lg)
+        .padding(.horizontal, Theme.Spacing.xl)
         .background(.quaternary.opacity(0.3), in: RoundedRectangle(cornerRadius: 12))
     }
 }

--- a/hledger-macos/Views/Transactions/TransactionFormView.swift
+++ b/hledger-macos/Views/Transactions/TransactionFormView.swift
@@ -60,8 +60,8 @@ struct TransactionFormView: View {
                             .foregroundStyle(Color.accentColor)
                         Spacer()
                     }
-                    .padding(.top, 20)
-                    .padding(.bottom, 20)
+                    .padding(.top, Theme.Spacing.xl)
+                    .padding(.bottom, Theme.Spacing.xl)
 
                     // Fields
                     VStack(spacing: 14) {
@@ -102,11 +102,11 @@ struct TransactionFormView: View {
                                 .focused($focusedField, equals: .comment)
                         }
                     }
-                    .padding(.horizontal, 24)
+                    .padding(.horizontal, Theme.Spacing.xxl)
 
                     // Postings
                     VStack(alignment: .leading, spacing: 8) {
-                        Divider().padding(.vertical, 12)
+                        Divider().padding(.vertical, Theme.Spacing.md)
 
                         Text("Postings")
                             .font(.subheadline.bold())
@@ -114,12 +114,12 @@ struct TransactionFormView: View {
                         Text("Amount: plain number (50.00), currency prefix (\(appState.config.defaultCommodity)50.00), or commodity with cost (-5 STCK @@ \(appState.config.defaultCommodity)200.00). Leave one amount blank to auto-balance.")
                             .font(.caption)
                             .foregroundStyle(.secondary)
-                            .padding(.bottom, 4)
+                            .padding(.bottom, Theme.Spacing.xs)
 
                         Text("Default commodity: \(appState.config.defaultCommodity)")
                             .font(.caption.italic())
                             .foregroundStyle(.tertiary)
-                            .padding(.bottom, 8)
+                            .padding(.bottom, Theme.Spacing.sm)
 
                         ForEach(Array(postingRows.enumerated()), id: \.element.id) { index, _ in
                             PostingRowField(
@@ -139,10 +139,10 @@ struct TransactionFormView: View {
                             Label("Add Posting", systemImage: "plus")
                         }
                         .controlSize(.small)
-                        .padding(.top, 4)
+                        .padding(.top, Theme.Spacing.xs)
                     }
-                    .padding(.horizontal, 24)
-                    .padding(.bottom, 16)
+                    .padding(.horizontal, Theme.Spacing.xxl)
+                    .padding(.bottom, Theme.Spacing.lg)
                 }
             }
 
@@ -167,8 +167,8 @@ struct TransactionFormView: View {
                     .keyboardShortcut(.defaultAction)
                     .disabled(isSaving || !isDateValid)
             }
-            .padding(.horizontal, 24)
-            .padding(.vertical, 12)
+            .padding(.horizontal, Theme.Spacing.xxl)
+            .padding(.vertical, Theme.Spacing.md)
         }
         .frame(width: 560, height: 580)
         .task { await loadAutocompleteData() }

--- a/hledger-macos/Views/Transactions/TransactionsView.swift
+++ b/hledger-macos/Views/Transactions/TransactionsView.swift
@@ -32,8 +32,8 @@ struct TransactionsView: View {
                     subtitle: SummaryCard.netSubtitle(for: appState.summaryCurrentMonth)
                 )
             }
-            .padding(.horizontal, 16)
-            .padding(.bottom, 12)
+            .padding(.horizontal, Theme.Spacing.lg)
+            .padding(.bottom, Theme.Spacing.md)
 
             Divider()
 


### PR DESCRIPTION
## Summary
- Sweep all 23 view files and replace **125 magic-number padding values** with `Theme.Spacing` tokens
- Extend `Theme.Spacing` with the gap values not previously covered (2, 3, 6, 10, 14, 32, 40), so the existing `xs/sm/md/lg/xl/xxl` scale stays intact and every padding has a token

## New tokens
Intermediate values get a `Plus` suffix to keep the t-shirt scale familiar:

| token       | pt |
|-------------|----|
| `xxs`       | 2  |
| `xxsPlus`   | 3  |
| `xs`        | 4  |
| `xsPlus`    | 6  |
| `sm`        | 8  |
| `smPlus`    | 10 |
| `md`        | 12 |
| `mdPlus`    | 14 |
| `lg`        | 16 |
| `xl`        | 20 |
| `xxl`       | 24 |
| `xxxl`      | 32 |
| `huge`      | 40 |

## Approach
The sweep was done with a small script (regex `.padding(.X, N)` and `.padding(N)`) so every numeric value is replaced 1:1. **No layout shift** is expected because no token rounds to a different value.

## Verification
- [x] Build succeeds
- [x] All 326 unit tests pass
- [x] Grep shows zero remaining numeric paddings under `Views/`
- [ ] Manual: open every screen and verify nothing visually shifted

Closes #88