### PR TITLE
refactor: extract FileSystemAccess and ShellRunner from BinaryDetector (#120)

### DIFF
--- a/hledger-macos/Backend/BinaryDetector.swift
+++ b/hledger-macos/Backend/BinaryDetector.swift
@@ -16,108 +16,43 @@ protocol BinaryDetecting {
     func detect(customHledgerPath: String) -> BinaryDetectionResult
 }
 
-/// Production implementation that delegates to the static BinaryDetector methods.
+/// Production implementation that delegates to the default BinaryDetector.
 struct LiveBinaryDetector: BinaryDetecting {
     func detect(customHledgerPath: String) -> BinaryDetectionResult {
-        BinaryDetector.detect(customHledgerPath: customHledgerPath)
+        BinaryDetector().detect(customHledgerPath: customHledgerPath)
     }
 }
 
-/// Scans for the hledger binary in known paths, user shell PATH, and configured locations.
-/// Also detects the journal file by running `hledger files` in a login shell.
-enum BinaryDetector {
-    /// Common installation paths on macOS.
-    private static var knownPaths: [String] {
-        let home = FileManager.default.homeDirectoryForCurrentUser.path
-        return [
-            "/opt/homebrew/bin/hledger",          // Apple Silicon Homebrew
-            "/usr/local/bin/hledger",             // Intel Homebrew / generic
-            "/usr/bin/hledger",                   // System
-            "\(home)/.local/bin/hledger",         // stack
-            "\(home)/.cabal/bin/hledger",         // cabal
-        ]
+// MARK: - Injection Protocols
+
+/// Filesystem access surface used by BinaryDetector. Injected for testing.
+protocol FileSystemAccess: Sendable {
+    func isExecutableFile(atPath path: String) -> Bool
+    func isDirectory(atPath path: String) -> Bool
+}
+
+/// Shell command runner used by BinaryDetector. Injected for testing.
+protocol ShellRunner: Sendable {
+    /// Run `shell` with `args` and return its stdout, or nil on failure / timeout.
+    func run(shell: String, args: [String], timeout: TimeInterval) -> String?
+}
+
+/// Live FileSystemAccess that wraps `FileManager.default`.
+struct LiveFileSystem: FileSystemAccess {
+    func isExecutableFile(atPath path: String) -> Bool {
+        FileManager.default.isExecutableFile(atPath: path)
     }
 
-    /// Detect the hledger binary and the journal file.
-    static func detect(customHledgerPath: String = "") -> BinaryDetectionResult {
-        let hledgerPath = findHledger(customPath: customHledgerPath)
-        let journalPath = hledgerPath.flatMap { journalPathFromHledger($0) }
-        return BinaryDetectionResult(hledgerPath: hledgerPath, detectedJournalPath: journalPath)
+    func isDirectory(atPath path: String) -> Bool {
+        var isDir: ObjCBool = false
+        let exists = FileManager.default.fileExists(atPath: path, isDirectory: &isDir)
+        return exists && isDir.boolValue
     }
+}
 
-    /// Find the hledger binary.
-    static func findHledger(customPath: String = "") -> String? {
-        // 1. User-configured custom path
-        if !customPath.isEmpty,
-           FileManager.default.isExecutableFile(atPath: customPath) {
-            return customPath
-        }
-
-        // 2. Check known filesystem paths directly
-        for path in knownPaths {
-            if FileManager.default.isExecutableFile(atPath: path) {
-                return path
-            }
-        }
-
-        // 3. Search user's shell PATH (covers stack, cabal, ghcup, nix, etc.)
-        for dir in loginShellPATH() {
-            let candidate = (dir as NSString).appendingPathComponent("hledger")
-            if FileManager.default.isExecutableFile(atPath: candidate) {
-                return candidate
-            }
-        }
-
-        return nil
-    }
-
-    /// Resolve the journal file by running `hledger files` in a login shell.
-    ///
-    /// Tries the user's configured shell first, then falls back to bash and zsh.
-    /// Exotic shells (e.g. osh) may fail at step 1 — that's fine, bash/zsh cover it.
-    static func journalPathFromHledger(_ hledgerPath: String) -> String? {
-        let userShell = ProcessInfo.processInfo.environment["SHELL"] ?? ""
-        // Deduplicated list: user shell first, then standard fallbacks
-        var shells = [userShell, "/bin/bash", "/bin/zsh"].filter { !$0.isEmpty }
-        // Remove duplicates while preserving order
-        var seen = Set<String>()
-        shells = shells.filter { seen.insert($0).inserted }
-
-        for shell in shells {
-            guard let output = shellOutput(shell: shell, args: ["-l", "-c", "\"\(hledgerPath)\" files"]),
-                  let firstLine = output.split(separator: "\n").first.map(String.init) else { continue }
-            let path = firstLine.trimmingCharacters(in: .whitespaces)
-            if !path.isEmpty {
-                return path
-            }
-        }
-        return nil
-    }
-
-    /// PATH directories from the user's login shell.
-    ///
-    /// GUI apps don't inherit the shell PATH, so we ask the shell explicitly.
-    static func loginShellPATH() -> [String] {
-        let shell = ProcessInfo.processInfo.environment["SHELL"] ?? "/bin/zsh"
-
-        // Try interactive login (-li) first, then plain login (-l)
-        for args in [["-li", "-c", "echo $PATH"], ["-l", "-c", "echo $PATH"]] {
-            guard let output = shellOutput(shell: shell, args: args) else { continue }
-            // Take the last non-empty line (shell may print motd or other output)
-            let pathString = output.split(separator: "\n")
-                .map { $0.trimmingCharacters(in: .whitespaces) }
-                .last { $0.contains("/") && !$0.isEmpty }
-            if let pathString, !pathString.isEmpty {
-                return pathString.split(separator: ":").map(String.init)
-            }
-        }
-        return []
-    }
-
-    // MARK: - Private
-
-    /// Run a shell command and return its stdout, with a 5-second timeout.
-    private static func shellOutput(shell: String, args: [String]) -> String? {
+/// Live ShellRunner that runs a real subprocess with a deadline.
+struct LiveShell: ShellRunner {
+    func run(shell: String, args: [String], timeout: TimeInterval) -> String? {
         let process = Process()
         process.executableURL = URL(fileURLWithPath: shell)
         process.arguments = args
@@ -132,7 +67,8 @@ enum BinaryDetector {
             return nil
         }
 
-        let deadline = DispatchTime.now() + .seconds(5)
+        let nanos = Int(timeout * 1_000_000_000)
+        let deadline = DispatchTime.now() + .nanoseconds(nanos)
         let done = DispatchSemaphore(value: 0)
         process.terminationHandler = { _ in done.signal() }
         if done.wait(timeout: deadline) == .timedOut {
@@ -142,5 +78,135 @@ enum BinaryDetector {
 
         let data = pipe.fileHandleForReading.readDataToEndOfFile()
         return String(data: data, encoding: .utf8)
+    }
+}
+
+// MARK: - BinaryDetector
+
+/// Scans for the hledger binary in known paths, user shell PATH, and configured locations.
+/// Also detects the journal file by running `hledger files` in a login shell.
+struct BinaryDetector {
+    let fileSystem: FileSystemAccess
+    let shell: ShellRunner
+    /// Timeout for any single shell invocation, in seconds.
+    let shellTimeout: TimeInterval
+
+    init(
+        fileSystem: FileSystemAccess = LiveFileSystem(),
+        shell: ShellRunner = LiveShell(),
+        shellTimeout: TimeInterval = 5
+    ) {
+        self.fileSystem = fileSystem
+        self.shell = shell
+        self.shellTimeout = shellTimeout
+    }
+
+    /// Common installation paths on macOS.
+    private var knownPaths: [String] {
+        let home = FileManager.default.homeDirectoryForCurrentUser.path
+        return [
+            "/opt/homebrew/bin/hledger",          // Apple Silicon Homebrew
+            "/usr/local/bin/hledger",             // Intel Homebrew / generic
+            "/usr/bin/hledger",                   // System
+            "\(home)/.local/bin/hledger",         // stack
+            "\(home)/.cabal/bin/hledger",         // cabal
+        ]
+    }
+
+    /// Detect the hledger binary and the journal file.
+    func detect(customHledgerPath: String = "") -> BinaryDetectionResult {
+        let hledgerPath = findHledger(customPath: customHledgerPath)
+        let journalPath = hledgerPath.flatMap { journalPathFromHledger($0) }
+        return BinaryDetectionResult(hledgerPath: hledgerPath, detectedJournalPath: journalPath)
+    }
+
+    /// Find the hledger binary.
+    func findHledger(customPath: String = "") -> String? {
+        // 1. User-configured custom path
+        if !customPath.isEmpty,
+           fileSystem.isExecutableFile(atPath: customPath) {
+            return customPath
+        }
+
+        // 2. Check known filesystem paths directly
+        for path in knownPaths {
+            if fileSystem.isExecutableFile(atPath: path) {
+                return path
+            }
+        }
+
+        // 3. Search user's shell PATH (covers stack, cabal, ghcup, nix, etc.)
+        for dir in loginShellPATH() {
+            let candidate = (dir as NSString).appendingPathComponent("hledger")
+            if fileSystem.isExecutableFile(atPath: candidate) {
+                return candidate
+            }
+        }
+
+        return nil
+    }
+
+    /// Resolve the journal file by running `hledger files` in a login shell.
+    ///
+    /// Tries the user's configured shell first, then falls back to bash and zsh.
+    /// Exotic shells (e.g. osh) may fail at step 1 — that's fine, bash/zsh cover it.
+    func journalPathFromHledger(_ hledgerPath: String) -> String? {
+        let userShell = ProcessInfo.processInfo.environment["SHELL"] ?? ""
+        // Deduplicated list: user shell first, then standard fallbacks
+        var shells = [userShell, "/bin/bash", "/bin/zsh"].filter { !$0.isEmpty }
+        // Remove duplicates while preserving order
+        var seen = Set<String>()
+        shells = shells.filter { seen.insert($0).inserted }
+
+        for sh in shells {
+            guard let output = shell.run(shell: sh, args: ["-l", "-c", "\"\(hledgerPath)\" files"], timeout: shellTimeout),
+                  let firstLine = output.split(separator: "\n").first.map(String.init) else { continue }
+            let path = firstLine.trimmingCharacters(in: .whitespaces)
+            if !path.isEmpty {
+                return path
+            }
+        }
+        return nil
+    }
+
+    /// PATH directories from the user's login shell.
+    ///
+    /// GUI apps don't inherit the shell PATH, so we ask the shell explicitly.
+    func loginShellPATH() -> [String] {
+        let sh = ProcessInfo.processInfo.environment["SHELL"] ?? "/bin/zsh"
+
+        // Try interactive login (-li) first, then plain login (-l)
+        for args in [["-li", "-c", "echo $PATH"], ["-l", "-c", "echo $PATH"]] {
+            guard let output = shell.run(shell: sh, args: args, timeout: shellTimeout) else { continue }
+            // Take the last non-empty line (shell may print motd or other output)
+            let pathString = output.split(separator: "\n")
+                .map { $0.trimmingCharacters(in: .whitespaces) }
+                .last { $0.contains("/") && !$0.isEmpty }
+            if let pathString, !pathString.isEmpty {
+                return pathString.split(separator: ":").map(String.init)
+            }
+        }
+        return []
+    }
+}
+
+// MARK: - Static convenience
+
+/// Backward-compatible static API that delegates to a default-initialized BinaryDetector.
+extension BinaryDetector {
+    static func detect(customHledgerPath: String = "") -> BinaryDetectionResult {
+        BinaryDetector().detect(customHledgerPath: customHledgerPath)
+    }
+
+    static func findHledger(customPath: String = "") -> String? {
+        BinaryDetector().findHledger(customPath: customPath)
+    }
+
+    static func journalPathFromHledger(_ hledgerPath: String) -> String? {
+        BinaryDetector().journalPathFromHledger(hledgerPath)
+    }
+
+    static func loginShellPATH() -> [String] {
+        BinaryDetector().loginShellPATH()
     }
 }

--- a/hledger-macosTests/hledger_macosTests.swift
+++ b/hledger-macosTests/hledger_macosTests.swift
@@ -1095,6 +1095,138 @@ struct BinaryDetectorTests {
     }
 }
 
+// MARK: - BinaryDetector Injection Tests
+//
+// These tests use mock FileSystemAccess and ShellRunner to exercise paths
+// that aren't reachable in the live-environment smoke tests above.
+
+/// FileSystemAccess mock that returns canned answers from a set of executable paths.
+private struct StubFileSystem: FileSystemAccess {
+    let executablePaths: Set<String>
+    let directoryPaths: Set<String>
+
+    init(executablePaths: Set<String> = [], directoryPaths: Set<String> = []) {
+        self.executablePaths = executablePaths
+        self.directoryPaths = directoryPaths
+    }
+
+    func isExecutableFile(atPath path: String) -> Bool { executablePaths.contains(path) }
+    func isDirectory(atPath path: String) -> Bool { directoryPaths.contains(path) }
+}
+
+/// ShellRunner mock that records calls and returns canned per-shell output.
+private final class StubShell: ShellRunner, @unchecked Sendable {
+    /// Outputs keyed by `(shell, args)`. A nil value simulates failure / timeout.
+    var outputs: [String: String?]
+    /// All `(shell, args)` calls observed, in order.
+    private(set) var calls: [(shell: String, args: [String])] = []
+
+    init(outputs: [String: String?] = [:]) {
+        self.outputs = outputs
+    }
+
+    static func key(shell: String, args: [String]) -> String {
+        "\(shell)|\(args.joined(separator: " "))"
+    }
+
+    func run(shell: String, args: [String], timeout: TimeInterval) -> String? {
+        calls.append((shell, args))
+        let key = Self.key(shell: shell, args: args)
+        return outputs[key] ?? nil
+    }
+}
+
+@Suite("BinaryDetector.injection")
+struct BinaryDetectorInjectionTests {
+    /// Custom path beats both knownPaths and shell PATH when all three would match.
+    @Test func customPathHasPriorityOverKnownAndShellPATH() {
+        let custom = "/custom/hledger"
+        // Mark every plausible path as executable so the only thing under test
+        // is the priority order, not the candidate set.
+        let fs = StubFileSystem(executablePaths: [
+            custom,
+            "/opt/homebrew/bin/hledger",
+            "/usr/local/bin/hledger",
+        ])
+        // Shell would return additional candidates, but we want to confirm we
+        // never get there because the custom path wins.
+        let shell = StubShell(outputs: [
+            StubShell.key(shell: "/bin/zsh", args: ["-li", "-c", "echo $PATH"]): "/some/dir"
+        ])
+        let detector = BinaryDetector(fileSystem: fs, shell: shell)
+
+        let result = detector.findHledger(customPath: custom)
+
+        #expect(result == custom)
+        #expect(shell.calls.isEmpty, "Shell must not be invoked when custom path matches")
+    }
+
+    /// `journalPathFromHledger` falls through to /bin/bash when the user's $SHELL fails.
+    @Test func journalPathFromHledgerFallsBackToBashWhenUserShellFails() {
+        // Use the live $SHELL the test process inherited so the keys line up
+        // with what BinaryDetector will actually call.
+        let userShell = ProcessInfo.processInfo.environment["SHELL"] ?? "/bin/zsh"
+        let hledgerPath = "/usr/local/bin/hledger"
+        let args = ["-l", "-c", "\"\(hledgerPath)\" files"]
+
+        // userShell returns nil (simulated failure); whichever shell comes
+        // SECOND in the dedup chain returns the expected journal path. Build
+        // the dict imperatively to avoid duplicate-key crashes when $SHELL is
+        // already /bin/bash or /bin/zsh.
+        var outputs: [String: String?] = [:]
+        outputs[StubShell.key(shell: userShell, args: args)] = nil
+        if userShell != "/bin/bash" {
+            outputs[StubShell.key(shell: "/bin/bash", args: args)] = "/Users/test/journal.journal\n"
+        }
+        if userShell != "/bin/zsh" {
+            // Only set zsh if it's not the user shell AND bash isn't supplying
+            // the answer (so we always have one fallback that succeeds).
+            if userShell == "/bin/bash" {
+                outputs[StubShell.key(shell: "/bin/zsh", args: args)] = "/Users/test/journal.journal\n"
+            } else {
+                outputs[StubShell.key(shell: "/bin/zsh", args: args)] = "/should/not/be/used\n"
+            }
+        }
+        let shell = StubShell(outputs: outputs)
+        let detector = BinaryDetector(fileSystem: StubFileSystem(), shell: shell)
+
+        let result = detector.journalPathFromHledger(hledgerPath)
+
+        #expect(result == "/Users/test/journal.journal")
+        #expect(shell.calls.count >= 2, "Expected at least one fallback after the first failure")
+    }
+
+    /// When every shell call times out (mocked as nil), the detector returns nil.
+    @Test func journalPathFromHledgerReturnsNilWhenAllShellsTimeOut() {
+        let shell = StubShell(outputs: [:])  // every key missing → nil → simulated timeout
+        let detector = BinaryDetector(fileSystem: StubFileSystem(), shell: shell)
+
+        let result = detector.journalPathFromHledger("/usr/local/bin/hledger")
+
+        #expect(result == nil)
+        #expect(!shell.calls.isEmpty, "Detector must attempt at least one shell call")
+    }
+
+    /// loginShellPATH parses the LAST path-like line from a multiline shell output
+    /// (real shells often print motd / banner lines before the echoed PATH).
+    @Test func loginShellPATHParsesLastLineFromMultilineOutput() {
+        let userShell = ProcessInfo.processInfo.environment["SHELL"] ?? "/bin/zsh"
+        let multiline = """
+        Welcome banner
+        Last login: yesterday
+        /usr/local/bin:/opt/homebrew/bin:/usr/bin
+        """
+        let shell = StubShell(outputs: [
+            StubShell.key(shell: userShell, args: ["-li", "-c", "echo $PATH"]): multiline
+        ])
+        let detector = BinaryDetector(fileSystem: StubFileSystem(), shell: shell)
+
+        let entries = detector.loginShellPATH()
+
+        #expect(entries == ["/usr/local/bin", "/opt/homebrew/bin", "/usr/bin"])
+    }
+}
+
 // MARK: - JournalWriter Routing Tests
 
 @Suite("JournalWriter.RoutingStrategy")


### PR DESCRIPTION
## Summary
Convert `BinaryDetector` from an enum of static methods into a struct with two injected dependencies:

- `FileSystemAccess` — wraps `FileManager` for executable / directory checks
- `ShellRunner` — wraps the `Process` subprocess invocation with a deadline

`LiveFileSystem` and `LiveShell` are the production implementations and the default initializer values, so existing call sites continue to work without changes.

The static methods (`BinaryDetector.detect`, `.findHledger`, `.journalPathFromHledger`, `.loginShellPATH`) are preserved as a convenience extension that delegates to a default instance, so the live-environment smoke tests in `hledger_macosTests` keep compiling and running unchanged.

## New tests
4 injection-based tests covering paths that were previously unreachable:

- `customPathHasPriorityOverKnownAndShellPATH` — verifies the priority order (custom > knownPaths > shell PATH)
- `journalPathFromHledgerFallsBackToBashWhenUserShellFails` — verifies the `$SHELL → /bin/bash → /bin/zsh` fallback chain
- `journalPathFromHledgerReturnsNilWhenAllShellsTimeOut` — verifies graceful failure when every shell call returns nil
- `loginShellPATHParsesLastLineFromMultilineOutput` — verifies that motd / banner lines are skipped and the last path-like line is parsed

Test count: **326 → 330**.

## Notes
- The `BinaryDetecting` protocol used by `AppStateTests` is unchanged
- `FileSystemAccess.isDirectory(atPath:)` is included in the protocol now even though it has no caller yet — it will be used by #121 (the directory-acceptance bug fix that follows immediately after this PR)

Closes #120