### PR TITLE
fix: reject directories as hledger binary in BinaryDetector (#121)

### DIFF
--- a/hledger-macos/Backend/BinaryDetector.swift
+++ b/hledger-macos/Backend/BinaryDetector.swift
@@ -123,27 +123,31 @@ struct BinaryDetector {
     /// Find the hledger binary.
     func findHledger(customPath: String = "") -> String? {
         // 1. User-configured custom path
-        if !customPath.isEmpty,
-           fileSystem.isExecutableFile(atPath: customPath) {
+        if !customPath.isEmpty, isExecutableRegularFile(customPath) {
             return customPath
         }
 
         // 2. Check known filesystem paths directly
-        for path in knownPaths {
-            if fileSystem.isExecutableFile(atPath: path) {
-                return path
-            }
+        for path in knownPaths where isExecutableRegularFile(path) {
+            return path
         }
 
         // 3. Search user's shell PATH (covers stack, cabal, ghcup, nix, etc.)
         for dir in loginShellPATH() {
             let candidate = (dir as NSString).appendingPathComponent("hledger")
-            if fileSystem.isExecutableFile(atPath: candidate) {
+            if isExecutableRegularFile(candidate) {
                 return candidate
             }
         }
 
         return nil
+    }
+
+    /// True only when `path` is an executable regular file.
+    /// Directories also have +x ("can list contents") so a plain
+    /// `isExecutableFile` check is not enough — see issue #121.
+    private func isExecutableRegularFile(_ path: String) -> Bool {
+        fileSystem.isExecutableFile(atPath: path) && !fileSystem.isDirectory(atPath: path)
     }
 
     /// Resolve the journal file by running `hledger files` in a login shell.

--- a/hledger-macosTests/hledger_macosTests.swift
+++ b/hledger-macosTests/hledger_macosTests.swift
@@ -1048,10 +1048,19 @@ struct BinaryDetectorTests {
         #expect(result != plainFile.path)
     }
 
-    // NOTE: A test for "directory rejected as custom path" was attempted and
-    // revealed a real bug — `FileManager.isExecutableFile(atPath:)` returns
-    // true for directories (they have +x for "list contents"). Tracked as a
-    // separate bug issue. Re-add the test as part of the fix.
+    /// Re-added after the directory-acceptance bug was fixed in #121.
+    /// `FileManager.isExecutableFile(atPath:)` returns true for directories
+    /// (they have +x for "list contents"), so the detector now also checks
+    /// `isDirectory` before accepting a candidate.
+    @Test func findHledgerRejectsDirectoryAsCustomPath() throws {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("BinaryDetectorTests-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let result = BinaryDetector.findHledger(customPath: dir.path)
+        #expect(result != dir.path, "Directory must not be accepted as the hledger binary")
+    }
 
     @Test func findHledgerEmptyCustomPathFallsThrough() {
         // Empty custom path must fall through to the known-paths search.
@@ -1205,6 +1214,34 @@ struct BinaryDetectorInjectionTests {
 
         #expect(result == nil)
         #expect(!shell.calls.isEmpty, "Detector must attempt at least one shell call")
+    }
+
+    /// Issue #121: a candidate that is a directory (with +x set so
+    /// `isExecutableFile` returns true) must NOT be accepted as the
+    /// hledger binary. Verified across all 3 candidate-checking branches:
+    /// custom path, knownPaths, and the shell PATH fallback.
+    @Test func findHledgerRejectsDirectoriesInAllCandidateBranches() {
+        let customDir = "/some/dir"
+        let knownDir  = "/opt/homebrew/bin/hledger"  // dressed-up dir at a knownPath
+        let pathDir   = "/usr/local/bin/hledger"     // dressed-up dir from shell PATH
+
+        // Mark every candidate as both "executable" (the bug) and "directory"
+        // (the fix path). The detector must skip every one of them.
+        let fs = StubFileSystem(
+            executablePaths: [customDir, knownDir, pathDir],
+            directoryPaths:  [customDir, knownDir, pathDir]
+        )
+        let userShell = ProcessInfo.processInfo.environment["SHELL"] ?? "/bin/zsh"
+        let shell = StubShell(outputs: [
+            StubShell.key(shell: userShell, args: ["-li", "-c", "echo $PATH"]): "/usr/local/bin"
+        ])
+        let detector = BinaryDetector(fileSystem: fs, shell: shell)
+
+        // Branch 1: custom path
+        #expect(detector.findHledger(customPath: customDir) == nil)
+        // Branch 2 & 3: with no custom path, the detector falls through
+        // knownPaths and the shell PATH — both populated with directories.
+        #expect(detector.findHledger(customPath: "") == nil)
     }
 
     /// loginShellPATH parses the LAST path-like line from a multiline shell output


### PR DESCRIPTION
## Summary
`FileManager.isExecutableFile(atPath:)` returns `true` for directories on macOS because directories carry the `+x` bit (its meaning for directories is "can list contents"). This made `BinaryDetector` silently accept a directory as the hledger binary in three places: the user's custom path, the `knownPaths` sweep, and the shell PATH fallback. Every subprocess call after that point would then fail opaquely.

## Fix
Add a small `isExecutableRegularFile` helper that combines `FileSystemAccess.isExecutableFile` with `!isDirectory`, and route all three candidate-checking branches in `findHledger` through it.

## Tests
- Re-add the live-environment test `findHledgerRejectsDirectoryAsCustomPath` (originally written and then removed in #97 with a forward reference to this fix)
- Add a deterministic mocked test `findHledgerRejectsDirectoriesInAllCandidateBranches` that exercises all three branches in one go using the new `FileSystemAccess` injection point

Test count: **330 → 332**.

## Base branch
This PR is stacked on top of #120 because it depends on the `FileSystemAccess.isDirectory` method introduced there.

Closes #121