### PR TITLE
refactor: standardize amount parsing on PostingAmountParser (#89)

### DIFF
--- a/hledger-macos/Views/Budget/BudgetFormView.swift
+++ b/hledger-macos/Views/Budget/BudgetFormView.swift
@@ -99,16 +99,17 @@ struct BudgetFormView: View {
     // MARK: - Save
 
     private func save() {
-        let (qty, commodity) = AmountParser.parse(amount)
-        guard qty != 0 else {
+        guard let parsed = PostingAmountParser.parse(
+            amount,
+            defaultCommodity: appState.config.defaultCommodity
+        ), parsed.quantity != 0 else {
             errorMessage = "Invalid amount"
             return
         }
 
-        let style = appState.styleForCommodity(commodity)
         let rule = BudgetRule(
             account: account,
-            amount: Amount(commodity: commodity, quantity: qty, style: style),
+            amount: parsed,
             category: category
         )
         onSave(rule)

--- a/hledger-macos/Views/Recurring/RecurringFormView.swift
+++ b/hledger-macos/Views/Recurring/RecurringFormView.swift
@@ -173,16 +173,14 @@ struct RecurringFormView: View {
     private func save() {
         var postings: [Posting] = []
         for row in postingRows where !row.account.isEmpty {
-            if row.amount.isEmpty {
-                postings.append(Posting(account: row.account))
+            if let amount = PostingAmountParser.parse(
+                row.amount,
+                defaultCommodity: appState.config.defaultCommodity
+            ) {
+                postings.append(Posting(account: row.account, amounts: [amount]))
             } else {
-                let (qty, commodity) = AmountParser.parse(row.amount)
-                let com = commodity.isEmpty ? appState.config.defaultCommodity : commodity
-                let style = appState.styleForCommodity(com)
-                postings.append(Posting(
-                    account: row.account,
-                    amounts: [Amount(commodity: com, quantity: qty, style: style)]
-                ))
+                // Empty or unparseable input → posting with no amount (auto-balance).
+                postings.append(Posting(account: row.account))
             }
         }
 


### PR DESCRIPTION
## Summary
Route `BudgetFormView` and `RecurringFormView` through `PostingAmountParser.parse()` so all three transaction-style forms (Transaction, Recurring, Budget) use the same canonical parser path that `TransactionFormView` already uses.

Removes the inline `AmountParser.parse()` + manual `Amount` construction in both forms.

## Behavior change
Amount style is now derived from the user input (decimal places, commodity position) instead of looked up via `appState.styleForCommodity(...)`. This matches `TransactionFormView`'s behavior. The visible effect: an amount typed in a Recurring or Budget form will be saved with a style derived from the typed string (e.g. `€500,00` keeps the comma decimal mark + symbol prefix) instead of inheriting the journal's existing style for that commodity.

Cost annotations like `-5 STCK @@ EUR742` now parse identically across the three forms. This was the explicit acceptance criterion in the issue.

## Test plan
- [x] Build succeeds
- [x] All 326 unit tests pass
- [ ] Manual: create a budget rule with `€500,00`, verify it saves and the rule shows `€500.00`
- [ ] Manual: create a recurring rule with two postings (one with amount, one blank), verify auto-balance still works
- [ ] Manual: edit an existing budget rule and re-save, verify the amount round-trips

Closes #89