### PR TITLE
chore: bump version to 0.2.2

### DIFF
--- a/hledger-macos.xcodeproj/project.pbxproj
+++ b/hledger-macos.xcodeproj/project.pbxproj
@@ -414,7 +414,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 0.2.1;
+				MARKETING_VERSION = 0.2.2;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.thesmokinator.hledger-macos";
 				PRODUCT_NAME = "hledger for Mac";
 				REGISTER_APP_GROUPS = YES;
@@ -448,7 +448,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 0.2.1;
+				MARKETING_VERSION = 0.2.2;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.thesmokinator.hledger-macos";
 				PRODUCT_NAME = "hledger for Mac";
 				REGISTER_APP_GROUPS = YES;


### PR DESCRIPTION
Bump \`MARKETING_VERSION\` from \`0.2.1\` to \`0.2.2\` in both Debug and Release configurations of the hledger-macos target.

## v0.2.2 milestone summary

9 PRs merged for v0.2.2 — all safe refactors, no behavior changes except where explicitly intended:

**Component extractions / DRY**
- #131 — \`refactor: use DateInputField in TransactionFormView (#85)\`
- #133 — \`refactor: extract confirmDeleteAlert modifier (#91)\`
- #134 — \`refactor: extract PeriodNavigator component (#90)\`
- #135 — \`refactor: extract LoadingOverlay component (#87)\`
- #132 — \`refactor: rename CsvPreviewTab files + align preview tables (#93)\`

**Design system**
- #136 — \`refactor: replace hardcoded paddings with Theme.Spacing tokens (#88)\` — sweeps 125 magic-number padding values across 23 view files

**Backend**
- #137 — \`refactor: extract FileSystemAccess and ShellRunner from BinaryDetector (#120)\` — adds dependency injection, +4 unit tests
- #140 — \`fix: reject directories as hledger binary in BinaryDetector (#121)\` — fixes a bug where \`FileManager.isExecutableFile\` returned true for directories, +2 unit tests
- #139 — \`refactor: standardize amount parsing on PostingAmountParser (#89)\` — unifies amount parser path across Transaction, Recurring, and Budget forms (intentional behavior change: amount style now derived from input, matches TransactionFormView)

**Test count: 326 → 332.**

This PR is the prerequisite for the \`v0.2.2\` tag — once merged, the tag will be created from \`main\` and CI will handle the release per the project workflow.