### PR TITLE
fix: respect commodity AmountStyle when parsing form input (#129)

### DIFF
--- a/examples/hledger-simple-eu/main.journal
+++ b/examples/hledger-simple-eu/main.journal
@@ -1,0 +1,313 @@
+; hledger for Mac — demo journal (single file, European number format)
+;
+; Companion to ../hledger-simple/main.journal but in TRUE European format:
+; - Decimal mark is `,` (comma)
+; - Digit-group separator is `.` (dot)
+; - The `commodity € 1.000,00` directive locks the format for hledger
+;   so any deviation (e.g. typing `€50.00` in a transaction) is parsed
+;   as 5000, not 50.
+;
+; This file is the fixture used to manually verify the fix for #129
+; (form input was being saved with the default `.` decimal mark and
+; then re-parsed as 100x against the declared commodity style).
+;
+; To use: point Settings > Journal File at this file.
+
+; --- Commodity declaration (the trigger for the #129 bug)
+commodity € 1.000,00
+
+account assets:bank:checking
+account assets:bank:savings
+account expenses:food:groceries
+account expenses:food:restaurant
+account expenses:housing:rent
+account expenses:housing:utilities
+account expenses:transport
+account expenses:subscriptions
+account expenses:shopping
+account expenses:health
+account expenses:entertainment
+account income:salary
+account income:freelance
+account liabilities:credit-card
+account liabilities:car-loan
+
+; === JANUARY 2026 ===
+
+2026-01-01 * Opening balances
+    assets:bank:checking              €5.000,00
+    assets:bank:savings               €12.000,00
+    liabilities:car-loan              €-8.500,00
+    equity:opening-balances
+
+2026-01-02 * Monthly salary
+    assets:bank:checking              €2.800,00
+    income:salary
+
+2026-01-03 * Rent
+    expenses:housing:rent             €750,00
+    assets:bank:checking
+
+2026-01-04 * Supermarket
+    expenses:food:groceries           €67,30
+    assets:bank:checking
+
+2026-01-07 * Electric bill
+    expenses:housing:utilities        €65,00
+    assets:bank:checking
+
+2026-01-10 * Netflix
+    expenses:subscriptions            €13,99
+    assets:bank:checking
+
+2026-01-11 * Supermarket
+    expenses:food:groceries           €52,80
+    assets:bank:checking
+
+2026-01-14 * Pizza night
+    expenses:food:restaurant          €32,00
+    assets:bank:checking
+
+2026-01-15 * Freelance invoice
+    assets:bank:checking              €400,00
+    income:freelance
+
+2026-01-17 * Gas station
+    expenses:transport                €55,00
+    assets:bank:checking
+
+2026-01-18 * Supermarket
+    expenses:food:groceries           €71,20
+    assets:bank:checking
+
+2026-01-20 * Car loan payment
+    liabilities:car-loan              €350,00
+    assets:bank:checking
+
+2026-01-22 * Gym
+    expenses:health                   €39,00
+    assets:bank:checking
+
+2026-01-25 * T-shirt online
+    expenses:shopping                 €29,00
+    liabilities:credit-card
+
+2026-01-27 * Credit card payment
+    liabilities:credit-card           €29,00
+    assets:bank:checking
+
+2026-01-28 * Savings
+    assets:bank:savings               €300,00
+    assets:bank:checking
+
+; === FEBRUARY 2026 ===
+
+2026-02-01 * Monthly salary
+    assets:bank:checking              €2.800,00
+    income:salary
+
+2026-02-02 * Rent
+    expenses:housing:rent             €750,00
+    assets:bank:checking
+
+2026-02-04 * Supermarket
+    expenses:food:groceries           €58,90
+    assets:bank:checking
+
+2026-02-06 * Water bill
+    expenses:housing:utilities        €38,00
+    assets:bank:checking
+
+2026-02-10 * Netflix
+    expenses:subscriptions            €13,99
+    assets:bank:checking
+
+2026-02-10 * Spotify
+    expenses:subscriptions            €9,99
+    assets:bank:checking
+
+2026-02-12 * Supermarket
+    expenses:food:groceries           €82,40
+    assets:bank:checking
+
+2026-02-14 * Valentine dinner
+    expenses:food:restaurant          €78,00
+    liabilities:credit-card
+
+2026-02-16 * Bus pass
+    expenses:transport                €45,00
+    assets:bank:checking
+
+2026-02-18 * Supermarket
+    expenses:food:groceries           €63,10
+    assets:bank:checking
+
+2026-02-20 * Car loan payment
+    liabilities:car-loan              €350,00
+    assets:bank:checking
+
+2026-02-22 * Gym
+    expenses:health                   €39,00
+    assets:bank:checking
+
+2026-02-24 * Movie tickets
+    expenses:entertainment            €22,00
+    assets:bank:checking
+
+2026-02-25 * New jacket
+    expenses:shopping                 €120,00
+    liabilities:credit-card
+
+2026-02-27 * Credit card payment
+    liabilities:credit-card           €198,00
+    assets:bank:checking
+
+2026-02-28 * Savings
+    assets:bank:savings               €250,00
+    assets:bank:checking
+
+; === MARCH 2026 ===
+
+2026-03-01 * Monthly salary
+    assets:bank:checking              €2.800,00
+    income:salary
+
+2026-03-02 * Rent
+    expenses:housing:rent             €750,00
+    assets:bank:checking
+
+2026-03-03 * Supermarket
+    expenses:food:groceries           €74,50
+    assets:bank:checking
+
+2026-03-05 * Internet bill
+    expenses:housing:utilities        €35,00
+    assets:bank:checking
+
+2026-03-07 * Sushi restaurant
+    expenses:food:restaurant          €45,00
+    assets:bank:checking
+
+2026-03-10 * Netflix
+    expenses:subscriptions            €13,99
+    assets:bank:checking
+
+2026-03-10 * Spotify
+    expenses:subscriptions            €9,99
+    assets:bank:checking
+
+2026-03-12 * Supermarket
+    expenses:food:groceries           €91,30
+    assets:bank:checking
+
+2026-03-15 * Freelance invoice
+    assets:bank:checking              €550,00
+    income:freelance
+
+2026-03-16 * Gas station
+    expenses:transport                €48,00
+    assets:bank:checking
+
+2026-03-18 * Supermarket
+    expenses:food:groceries           €55,80
+    assets:bank:checking
+
+2026-03-20 * Car loan payment
+    liabilities:car-loan              €350,00
+    assets:bank:checking
+
+2026-03-22 * Gym
+    expenses:health                   €39,00
+    assets:bank:checking
+
+2026-03-24 * Concert
+    expenses:entertainment            €55,00
+    liabilities:credit-card
+
+2026-03-25 * Books
+    expenses:shopping                 €42,00
+    assets:bank:checking
+
+2026-03-27 * Credit card payment
+    liabilities:credit-card           €55,00
+    assets:bank:checking
+
+2026-03-28 * Savings
+    assets:bank:savings               €400,00
+    assets:bank:checking
+
+; === APRIL 2026 ===
+
+2026-04-01 * Monthly salary
+    assets:bank:checking              €2.800,00
+    income:salary
+
+2026-04-01 * Rent
+    expenses:housing:rent             €750,00
+    assets:bank:checking
+
+2026-04-02 * Supermarket
+    expenses:food:groceries           €83,20
+    assets:bank:checking
+
+2026-04-03 * Electric bill
+    expenses:housing:utilities        €71,00
+    assets:bank:checking
+
+2026-04-05 * Restaurant
+    expenses:food:restaurant          €38,00
+    assets:bank:checking
+
+2026-04-07 * Supermarket
+    expenses:food:groceries           €66,40
+    assets:bank:checking
+
+2026-04-10 * Netflix
+    expenses:subscriptions            €13,99
+    assets:bank:checking
+
+2026-04-10 * Spotify
+    expenses:subscriptions            €9,99
+    assets:bank:checking
+
+2026-04-12 * Gas station
+    expenses:transport                €52,00
+    assets:bank:checking
+
+2026-04-15 * Dentist
+    expenses:health                   €85,00
+    assets:bank:checking
+
+2026-04-18 * Supermarket
+    expenses:food:groceries           €72,90
+    assets:bank:checking
+
+2026-04-20 * Car loan payment
+    liabilities:car-loan              €350,00
+    assets:bank:checking
+
+2026-04-22 * Gym
+    expenses:health                   €39,00
+    assets:bank:checking
+
+2026-04-25 * Museum
+    expenses:entertainment            €18,00
+    assets:bank:checking
+
+; === EDGE CASES: comments, balance assertions, multi-commodity ===
+
+2026-04-26 * Weekly groceries  ; family shopping trip
+    expenses:food:groceries                         €95,50  ; organic produce
+    assets:bank:checking  ; paid with debit card
+
+2026-04-27 * Salary with assertion
+    assets:bank:checking              €2.800,00 = €12.449,77
+    income:salary
+
+2026-04-28 * Freelance USD payment  ; foreign client
+    assets:bank:checking              $500.00
+    income:freelance
+
+2026-04-29 * Amazon US purchase
+    expenses:shopping                 $35.00
+    assets:bank:checking              €-32,50

--- a/hledger-macos/Backend/BudgetManager.swift
+++ b/hledger-macos/Backend/BudgetManager.swift
@@ -40,7 +40,7 @@ enum BudgetManager {
     // MARK: - Parse Rules
 
     /// Parse budget rules from budget.journal.
-    static func parseRules(budgetPath: URL, commodityStyles: [String: AmountStyle] = [:]) -> [BudgetRule] {
+    static func parseRules(budgetPath: URL) -> [BudgetRule] {
         guard FileManager.default.fileExists(atPath: budgetPath.path),
               let content = try? String(contentsOf: budgetPath, encoding: .utf8),
               !content.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
@@ -70,14 +70,16 @@ enum BudgetManager {
                     let account = String(match.1).trimmingCharacters(in: .whitespaces)
                     let amountStr = String(match.2).trimmingCharacters(in: .whitespaces)
                     let category = match.3.map { String($0).trimmingCharacters(in: .whitespaces) } ?? ""
-                    let (quantity, commodity) = AmountParser.parse(amountStr)
-                    let style = commodityStyles[commodity] ?? .default
-
-                    rules.append(BudgetRule(
-                        account: account,
-                        amount: Amount(commodity: commodity, quantity: quantity, style: style),
-                        category: category
-                    ))
+                    // Use PostingAmountParser so the loaded Amount inherits its
+                    // full style (decimalMark, digitGroupSeparator, precision)
+                    // from the literal — same path as form input. See #129.
+                    if let amount = PostingAmountParser.parseSimple(amountStr) {
+                        rules.append(BudgetRule(
+                            account: account,
+                            amount: amount,
+                            category: category
+                        ))
+                    }
                 }
             }
         }
@@ -137,10 +139,10 @@ enum BudgetManager {
     // MARK: - CRUD
 
     /// Add a new budget rule.
-    static func addRule(_ rule: BudgetRule, journalFile: URL, validator: any AccountingBackend, commodityStyles: [String: AmountStyle] = [:]) async throws {
+    static func addRule(_ rule: BudgetRule, journalFile: URL, validator: any AccountingBackend) async throws {
         let path = budgetPath(for: journalFile)
         try ensureBudgetFile(journalFile: journalFile)
-        var rules = parseRules(budgetPath: path, commodityStyles: commodityStyles)
+        var rules = parseRules(budgetPath: path)
         if rules.contains(where: { $0.account == rule.account }) {
             throw BackendError.commandFailed("Budget rule already exists for \(rule.account)")
         }
@@ -149,9 +151,9 @@ enum BudgetManager {
     }
 
     /// Update an existing budget rule.
-    static func updateRule(oldAccount: String, newRule: BudgetRule, journalFile: URL, validator: any AccountingBackend, commodityStyles: [String: AmountStyle] = [:]) async throws {
+    static func updateRule(oldAccount: String, newRule: BudgetRule, journalFile: URL, validator: any AccountingBackend) async throws {
         let path = budgetPath(for: journalFile)
-        var rules = parseRules(budgetPath: path, commodityStyles: commodityStyles)
+        var rules = parseRules(budgetPath: path)
         guard let index = rules.firstIndex(where: { $0.account == oldAccount }) else {
             throw BackendError.commandFailed("No budget rule found for \(oldAccount)")
         }
@@ -160,9 +162,9 @@ enum BudgetManager {
     }
 
     /// Delete a budget rule by account name.
-    static func deleteRule(account: String, journalFile: URL, validator: any AccountingBackend, commodityStyles: [String: AmountStyle] = [:]) async throws {
+    static func deleteRule(account: String, journalFile: URL, validator: any AccountingBackend) async throws {
         let path = budgetPath(for: journalFile)
-        var rules = parseRules(budgetPath: path, commodityStyles: commodityStyles)
+        var rules = parseRules(budgetPath: path)
         let count = rules.count
         rules.removeAll { $0.account == account }
         if rules.count == count {

--- a/hledger-macos/Backend/RecurringManager.swift
+++ b/hledger-macos/Backend/RecurringManager.swift
@@ -40,7 +40,7 @@ enum RecurringManager {
 
     // MARK: - Parse Rules
 
-    static func parseRules(recurringPath: URL, commodityStyles: [String: AmountStyle] = [:]) -> [RecurringRule] {
+    static func parseRules(recurringPath: URL) -> [RecurringRule] {
         guard FileManager.default.fileExists(atPath: recurringPath.path),
               let content = try? String(contentsOf: recurringPath, encoding: .utf8),
               !content.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
@@ -93,12 +93,14 @@ enum RecurringManager {
                 if let match = line.firstMatch(of: postingPattern) {
                     let account = String(match.1).trimmingCharacters(in: .whitespaces)
                     let amountStr = String(match.2).trimmingCharacters(in: .whitespaces)
-                    let (qty, commodity) = AmountParser.parse(amountStr)
-                    let style = commodityStyles[commodity] ?? .default
-                    currentPostings.append(Posting(
-                        account: account,
-                        amounts: [Amount(commodity: commodity, quantity: qty, style: style)]
-                    ))
+                    // Use PostingAmountParser so the loaded Amount inherits its
+                    // full style (decimalMark, digitGroupSeparator, precision)
+                    // from the literal — same path as form input. See #129.
+                    if let amount = PostingAmountParser.parseSimple(amountStr) {
+                        currentPostings.append(Posting(account: account, amounts: [amount]))
+                    } else {
+                        currentPostings.append(Posting(account: account))
+                    }
                 } else {
                     // Balancing posting (no amount)
                     let account = line.trimmingCharacters(in: .whitespaces)
@@ -174,10 +176,10 @@ enum RecurringManager {
 
     // MARK: - CRUD
 
-    static func addRule(_ rule: RecurringRule, journalFile: URL, validator: any AccountingBackend, commodityStyles: [String: AmountStyle] = [:]) async throws {
+    static func addRule(_ rule: RecurringRule, journalFile: URL, validator: any AccountingBackend) async throws {
         let path = recurringPath(for: journalFile)
         try ensureRecurringFile(journalFile: journalFile)
-        var rules = parseRules(recurringPath: path, commodityStyles: commodityStyles)
+        var rules = parseRules(recurringPath: path)
         if rules.contains(where: { $0.ruleId == rule.ruleId }) {
             throw BackendError.commandFailed("Recurring rule already exists with id: \(rule.ruleId)")
         }
@@ -185,9 +187,9 @@ enum RecurringManager {
         try await writeRules(rules, recurringPath: path, journalFile: journalFile, validator: validator)
     }
 
-    static func updateRule(ruleId: String, newRule: RecurringRule, journalFile: URL, validator: any AccountingBackend, commodityStyles: [String: AmountStyle] = [:]) async throws {
+    static func updateRule(ruleId: String, newRule: RecurringRule, journalFile: URL, validator: any AccountingBackend) async throws {
         let path = recurringPath(for: journalFile)
-        var rules = parseRules(recurringPath: path, commodityStyles: commodityStyles)
+        var rules = parseRules(recurringPath: path)
         guard let index = rules.firstIndex(where: { $0.ruleId == ruleId }) else {
             throw BackendError.commandFailed("No recurring rule found with id: \(ruleId)")
         }
@@ -195,9 +197,9 @@ enum RecurringManager {
         try await writeRules(rules, recurringPath: path, journalFile: journalFile, validator: validator)
     }
 
-    static func deleteRule(ruleId: String, journalFile: URL, validator: any AccountingBackend, commodityStyles: [String: AmountStyle] = [:]) async throws {
+    static func deleteRule(ruleId: String, journalFile: URL, validator: any AccountingBackend) async throws {
         let path = recurringPath(for: journalFile)
-        var rules = parseRules(recurringPath: path, commodityStyles: commodityStyles)
+        var rules = parseRules(recurringPath: path)
         let count = rules.count
         rules.removeAll { $0.ruleId == ruleId }
         if rules.count == count {

--- a/hledger-macos/Config/PostingAmountParser.swift
+++ b/hledger-macos/Config/PostingAmountParser.swift
@@ -32,6 +32,12 @@ enum PostingAmountParser {
 
     // MARK: - Public API
 
+    /// Closure that resolves the journal-declared `AmountStyle` for a given commodity,
+    /// or returns `nil` if the commodity is not declared (in which case the parser keeps
+    /// its input-derived style). See `AppState.parseFormAmount(_:)` for the production
+    /// resolver and issue #129 for the bug this guards against.
+    typealias StyleResolver = (String) -> AmountStyle?
+
     /// Parse a posting amount string into an `Amount`.
     ///
     /// Tries the cost-annotated pattern first (`qty COMMODITY @@ cost`); falls
@@ -40,22 +46,36 @@ enum PostingAmountParser {
     /// - Parameters:
     ///   - input: The raw user-entered amount string.
     ///   - defaultCommodity: Commodity to use when the input has no explicit one.
+    ///   - styleResolver: Optional closure that returns the journal-declared
+    ///     `AmountStyle` for a commodity. When provided and non-nil for the
+    ///     resolved commodity, its `decimalMark`, `digitGroupSeparator`, and
+    ///     `digitGroupSizes` override the input-derived defaults so that
+    ///     `Amount.formatted()` produces a string hledger round-trips
+    ///     correctly. See #129.
     /// - Returns: An `Amount` if parsing succeeds, `nil` otherwise.
-    static func parse(_ input: String, defaultCommodity: String = "") -> Amount? {
+    static func parse(
+        _ input: String,
+        defaultCommodity: String = "",
+        styleResolver: StyleResolver? = nil
+    ) -> Amount? {
         let trimmed = input.trimmingCharacters(in: .whitespaces)
         guard !trimmed.isEmpty else { return nil }
 
-        if let amount = parseCostAnnotated(trimmed, defaultCommodity: defaultCommodity) {
+        if let amount = parseCostAnnotated(trimmed, defaultCommodity: defaultCommodity, styleResolver: styleResolver) {
             return amount
         }
-        return parseSimple(trimmed, defaultCommodity: defaultCommodity)
+        return parseSimple(trimmed, defaultCommodity: defaultCommodity, styleResolver: styleResolver)
     }
 
     /// Parse a cost-annotated amount like `-5 XDWD @@ €742,55` or `-5 XDWD @ €148.518`.
     ///
     /// Returns `nil` if the input does not match the cost pattern or if either the
     /// quantity or the cost portion cannot be parsed.
-    static func parseCostAnnotated(_ input: String, defaultCommodity: String = "") -> Amount? {
+    static func parseCostAnnotated(
+        _ input: String,
+        defaultCommodity: String = "",
+        styleResolver: StyleResolver? = nil
+    ) -> Amount? {
         let trimmed = input.trimmingCharacters(in: .whitespaces)
         guard let match = trimmed.firstMatch(of: costRegex) else { return nil }
 
@@ -67,7 +87,7 @@ enum PostingAmountParser {
         let qty = AmountParser.parseNumber(qtyStr)
         guard qty != 0 else { return nil }
 
-        guard let costAmount = parseSimple(costStr, defaultCommodity: defaultCommodity) else {
+        guard let costAmount = parseSimple(costStr, defaultCommodity: defaultCommodity, styleResolver: styleResolver) else {
             return nil
         }
 
@@ -87,11 +107,12 @@ enum PostingAmountParser {
             style: costAmount.style
         )
 
-        let style = AmountStyle(
+        var style = AmountStyle(
             commoditySide: .right,
             commoditySpaced: true,
             precision: decimalPlaces(in: qtyStr)
         )
+        applyJournalStyle(&style, for: commodity, resolver: styleResolver)
 
         return Amount(commodity: commodity, quantity: qty, style: style, cost: cost)
     }
@@ -100,7 +121,11 @@ enum PostingAmountParser {
     ///
     /// Returns `nil` for empty input or for plain `0` with no commodity (treated as
     /// "no amount", consistent with the existing TransactionFormView behaviour).
-    static func parseSimple(_ input: String, defaultCommodity: String = "") -> Amount? {
+    static func parseSimple(
+        _ input: String,
+        defaultCommodity: String = "",
+        styleResolver: StyleResolver? = nil
+    ) -> Amount? {
         let trimmed = input.trimmingCharacters(in: .whitespaces)
         guard !trimmed.isEmpty else { return nil }
 
@@ -110,7 +135,8 @@ enum PostingAmountParser {
         if qty == 0 && commodity.isEmpty { return nil }
 
         let effectiveCommodity = commodity.isEmpty ? defaultCommodity : commodity
-        let style = styleFor(commodity: effectiveCommodity, rawInput: trimmed)
+        var style = styleFor(commodity: effectiveCommodity, rawInput: trimmed)
+        applyJournalStyle(&style, for: effectiveCommodity, resolver: styleResolver)
 
         return Amount(commodity: effectiveCommodity, quantity: qty, style: style)
     }
@@ -122,8 +148,9 @@ enum PostingAmountParser {
     ///
     /// - Single-character commodities (e.g. `€`, `$`) are placed on the left with no space.
     /// - Multi-character commodities (e.g. `EUR`, `SWDA`) are placed on the right with a space.
-    /// - `decimalMark` is always `.` (the hledger default) so `Amount.formatted()`
-    ///   produces hledger-compatible output.
+    /// - `decimalMark` is always `.` (the hledger default). Callers MUST pass a
+    ///   `styleResolver` (via `applyJournalStyle`) so European-format commodities
+    ///   round-trip correctly — see #129.
     private static func styleFor(commodity: String, rawInput: String) -> AmountStyle {
         let isSymbol = commodity.count == 1
         return AmountStyle(
@@ -131,6 +158,25 @@ enum PostingAmountParser {
             commoditySpaced: !isSymbol,
             precision: decimalPlaces(in: rawInput)
         )
+    }
+
+    /// Override the input-derived `decimalMark` / `digitGroupSeparator` /
+    /// `digitGroupSizes` of `style` with the journal-declared style for
+    /// `commodity` if the resolver returns a non-nil value. Side, spacing and
+    /// input-derived precision are kept so the user-typed shape is preserved.
+    ///
+    /// This is the fix for #129: without it, an Amount written by the form
+    /// uses `decimalMark = "."` and a journal that declares
+    /// `commodity € 1.000,00` re-parses `€1.00` as `100`.
+    private static func applyJournalStyle(
+        _ style: inout AmountStyle,
+        for commodity: String,
+        resolver: StyleResolver?
+    ) {
+        guard let resolved = resolver?(commodity) else { return }
+        style.decimalMark = resolved.decimalMark
+        style.digitGroupSeparator = resolved.digitGroupSeparator
+        style.digitGroupSizes = resolved.digitGroupSizes
     }
 
     /// Return the number of decimal places in a raw number string.

--- a/hledger-macos/Config/PostingAmountParser.swift
+++ b/hledger-macos/Config/PostingAmountParser.swift
@@ -143,19 +143,28 @@ enum PostingAmountParser {
 
     // MARK: - Helpers
 
-    /// Build an `AmountStyle` for a parsed commodity, deriving side, spacing and
-    /// precision from the raw input string.
+    /// Build an `AmountStyle` for a parsed commodity, deriving every field from
+    /// the raw input string so the user-typed shape round-trips intact even
+    /// without a `styleResolver`.
     ///
     /// - Single-character commodities (e.g. `€`, `$`) are placed on the left with no space.
     /// - Multi-character commodities (e.g. `EUR`, `SWDA`) are placed on the right with a space.
-    /// - `decimalMark` is always `.` (the hledger default). Callers MUST pass a
-    ///   `styleResolver` (via `applyJournalStyle`) so European-format commodities
-    ///   round-trip correctly — see #129.
+    /// - `decimalMark` and `digitGroupSeparator` come from `detectFormat(in:)`,
+    ///   so `1,00 €` produces `decimalMark = ","` even with no resolver and
+    ///   `1.000,00` also gets `digitGroupSeparator = "."`. Callers can still
+    ///   pass a `styleResolver` (via `applyJournalStyle`) to OVERRIDE the
+    ///   input-derived values with the journal-declared style — that is the
+    ///   safety net when the user types in the "wrong" format and we want to
+    ///   normalise on save.
     private static func styleFor(commodity: String, rawInput: String) -> AmountStyle {
         let isSymbol = commodity.count == 1
+        let format = detectFormat(in: rawInput)
         return AmountStyle(
             commoditySide: isSymbol ? .left : .right,
             commoditySpaced: !isSymbol,
+            decimalMark: format.decimalMark,
+            digitGroupSeparator: format.digitGroupSeparator,
+            digitGroupSizes: format.digitGroupSeparator != nil ? [3] : [],
             precision: decimalPlaces(in: rawInput)
         )
     }
@@ -181,37 +190,72 @@ enum PostingAmountParser {
 
     /// Return the number of decimal places in a raw number string.
     ///
-    /// Handles both US (`1,000.00`) and European (`1.000,00`) formats using the
-    /// same heuristic as `AmountParser.parseNumber`:
-    /// - If both `.` and `,` are present, the last one is the decimal mark.
-    /// - If only `,` is present, it's treated as decimal when ≤2 digits follow,
-    ///   otherwise as a thousands separator.
-    /// - If only `.` is present, it's always the decimal mark.
+    /// Strips both leading and trailing non-numeric characters before
+    /// counting, so inputs like `1,00 €` or `-1.234,56 EUR` work the same
+    /// as `€1,00` and `-€1.234,56`. Without the trailing strip, `1,00 €`
+    /// would return 0 because `"00 €"` is not all-numeric — that was the
+    /// root cause of the precision-lost variant of #129.
     static func decimalPlaces(in s: String) -> Int {
-        // Strip leading minus and any non-numeric prefix (e.g. currency symbol)
-        let core = s.drop(while: { !$0.isNumber && $0 != "." && $0 != "," })
+        let core = stripNonNumericEdges(s)
         guard !core.isEmpty else { return 0 }
 
+        let format = detectFormat(in: s)
+        guard let lastMark = core.lastIndex(of: Character(format.decimalMark)) else { return 0 }
+        // Count only digits after the decimal mark — any trailing non-digits
+        // are already stripped by stripNonNumericEdges, but be defensive.
+        return core[core.index(after: lastMark)...].filter(\.isNumber).count
+    }
+
+    /// Detect the decimal mark and (optional) digit-group separator from a raw
+    /// number string, looking only at the leading/trailing-stripped numeric core.
+    ///
+    /// - Both `.` and `,` present: the **last** one is the decimal mark, the
+    ///   other is the digit-group separator (`1.000,00` → European,
+    ///   `1,000.00` → US).
+    /// - Only `,` present: it is the decimal mark when ≤2 digits follow it
+    ///   (`50,00`), otherwise it is interpreted as a thousands separator
+    ///   (`1,000` → 1000 with `","` digit group, no fractional part).
+    /// - Only `.` present, or neither: `.` is the decimal mark, no group
+    ///   separator.
+    static func detectFormat(in s: String) -> (decimalMark: String, digitGroupSeparator: String?) {
+        let core = stripNonNumericEdges(s)
         let hasDot = core.contains(".")
         let hasComma = core.contains(",")
-        guard hasDot || hasComma else { return 0 }
 
-        let decimalMark: Character
         if hasDot && hasComma {
             let lastDot = core.lastIndex(of: ".")!
             let lastComma = core.lastIndex(of: ",")!
-            decimalMark = lastComma > lastDot ? "," : "."
-        } else if hasComma {
-            let lastComma = core.lastIndex(of: ",")!
-            let afterComma = core[core.index(after: lastComma)...]
-            // ≤2 digits after comma → decimal; otherwise thousands separator
-            guard afterComma.count <= 2 && afterComma.allSatisfy(\.isNumber) else { return 0 }
-            decimalMark = ","
-        } else {
-            decimalMark = "."
+            if lastComma > lastDot {
+                return (decimalMark: ",", digitGroupSeparator: ".")
+            } else {
+                return (decimalMark: ".", digitGroupSeparator: ",")
+            }
         }
 
-        guard let lastMark = core.lastIndex(of: decimalMark) else { return 0 }
-        return core.distance(from: core.index(after: lastMark), to: core.endIndex)
+        if hasComma {
+            let lastComma = core.lastIndex(of: ",")!
+            let afterComma = core[core.index(after: lastComma)...]
+            if afterComma.count <= 2 && afterComma.allSatisfy(\.isNumber) {
+                return (decimalMark: ",", digitGroupSeparator: nil)
+            } else {
+                return (decimalMark: ".", digitGroupSeparator: ",")
+            }
+        }
+
+        return (decimalMark: ".", digitGroupSeparator: nil)
+    }
+
+    /// Strip non-numeric characters from BOTH ends of a literal amount string,
+    /// leaving only the contiguous numeric core (digits, `.`, `,` and any
+    /// embedded `-` for the sign which is treated as numeric here too).
+    private static func stripNonNumericEdges(_ s: String) -> Substring {
+        var core = Substring(s)
+        while let first = core.first, !first.isNumber && first != "." && first != "," {
+            core = core.dropFirst()
+        }
+        while let last = core.last, !last.isNumber && last != "." && last != "," {
+            core = core.dropLast()
+        }
+        return core
     }
 }

--- a/hledger-macos/Models/Transaction.swift
+++ b/hledger-macos/Models/Transaction.swift
@@ -80,7 +80,7 @@ struct Amount: Codable, Hashable, Sendable {
 
     /// Format the amount as a display string.
     func formatted() -> String {
-        let qtyStr = formatDecimal(abs(quantity), precision: style.precision)
+        let qtyStr = Self.formatDecimal(abs(quantity), style: style)
         let sign = quantity < 0 ? "-" : ""
         let space = style.commoditySpaced ? " " : ""
 
@@ -93,7 +93,11 @@ struct Amount: Codable, Hashable, Sendable {
         }
 
         if let cost = cost {
-            let costDisplay = formatDecimal(abs(cost.quantity), precision: cost.style.precision)
+            // Use the cost's OWN style — not self.style — so a multi-currency
+            // cost-annotated amount like `-5 XDWD @@ €742,55` formats the cost
+            // portion with the € commodity's decimal mark, not the XDWD one.
+            // See #129.
+            let costDisplay = Self.formatDecimal(abs(cost.quantity), style: cost.style)
             let costSpace = cost.style.commoditySpaced ? " " : ""
             let costStr: String
             switch cost.style.commoditySide {
@@ -113,11 +117,14 @@ struct Amount: Codable, Hashable, Sendable {
         AmountFormatter.format(quantity, commodity: commodity)
     }
 
-    private func formatDecimal(_ value: Decimal, precision: Int) -> String {
+    /// Format a decimal value using the supplied `AmountStyle`. Static so the
+    /// caller can pass a style that is not necessarily `self.style` — needed
+    /// to format a cost annotation that has its own commodity and style.
+    private static func formatDecimal(_ value: Decimal, style: AmountStyle) -> String {
         let formatter = NumberFormatter()
         formatter.numberStyle = .decimal
-        formatter.minimumFractionDigits = precision
-        formatter.maximumFractionDigits = precision
+        formatter.minimumFractionDigits = style.precision
+        formatter.maximumFractionDigits = style.precision
         formatter.decimalSeparator = style.decimalMark
 
         if let separator = style.digitGroupSeparator, !style.digitGroupSizes.isEmpty {

--- a/hledger-macos/Services/AppState.swift
+++ b/hledger-macos/Services/AppState.swift
@@ -193,6 +193,20 @@ final class AppState {
         commodityStyles[commodity] ?? .default
     }
 
+    /// Parse user-entered amount input from a form, automatically applying the
+    /// journal's commodity style so European-format commodities round-trip
+    /// correctly. **All form callsites must go through this method**, never
+    /// call `PostingAmountParser.parse(_:)` directly. See #129.
+    func parseFormAmount(_ input: String) -> Amount? {
+        PostingAmountParser.parse(
+            input,
+            defaultCommodity: config.defaultCommodity,
+            styleResolver: { [weak self] commodity in
+                self?.commodityStyles[commodity]
+            }
+        )
+    }
+
     /// Extract commodity styles from loaded transactions (zero I/O cost).
     private func extractCommodityStyles() {
         var styles: [String: AmountStyle] = [:]

--- a/hledger-macos/Views/Budget/BudgetFormView.swift
+++ b/hledger-macos/Views/Budget/BudgetFormView.swift
@@ -99,10 +99,7 @@ struct BudgetFormView: View {
     // MARK: - Save
 
     private func save() {
-        guard let parsed = PostingAmountParser.parse(
-            amount,
-            defaultCommodity: appState.config.defaultCommodity
-        ), parsed.quantity != 0 else {
+        guard let parsed = appState.parseFormAmount(amount), parsed.quantity != 0 else {
             errorMessage = "Invalid amount"
             return
         }

--- a/hledger-macos/Views/Budget/BudgetView.swift
+++ b/hledger-macos/Views/Budget/BudgetView.swift
@@ -142,7 +142,7 @@ struct BudgetView: View {
         isLoading = true
 
         let budgetPath = BudgetManager.budgetPath(for: backend.journalFile)
-        rules = BudgetManager.parseRules(budgetPath: budgetPath, commodityStyles: appState.commodityStyles)
+        rules = BudgetManager.parseRules(budgetPath: budgetPath)
 
         do {
             actuals = try await backend.loadBudgetReport(period: currentPeriod)
@@ -214,15 +214,13 @@ struct BudgetView: View {
                     oldAccount: editing.account,
                     newRule: newRule,
                     journalFile: backend.journalFile,
-                    validator: backend,
-                    commodityStyles: appState.commodityStyles
+                    validator: backend
                 )
             } else {
                 try await BudgetManager.addRule(
                     newRule,
                     journalFile: backend.journalFile,
-                    validator: backend,
-                    commodityStyles: appState.commodityStyles
+                    validator: backend
                 )
             }
             await loadData()
@@ -237,8 +235,7 @@ struct BudgetView: View {
             try await BudgetManager.deleteRule(
                 account: rule.account,
                 journalFile: backend.journalFile,
-                validator: backend,
-                commodityStyles: appState.commodityStyles
+                validator: backend
             )
             await loadData()
         } catch {

--- a/hledger-macos/Views/Recurring/RecurringFormView.swift
+++ b/hledger-macos/Views/Recurring/RecurringFormView.swift
@@ -173,10 +173,7 @@ struct RecurringFormView: View {
     private func save() {
         var postings: [Posting] = []
         for row in postingRows where !row.account.isEmpty {
-            if let amount = PostingAmountParser.parse(
-                row.amount,
-                defaultCommodity: appState.config.defaultCommodity
-            ) {
+            if let amount = appState.parseFormAmount(row.amount) {
                 postings.append(Posting(account: row.account, amounts: [amount]))
             } else {
                 // Empty or unparseable input → posting with no amount (auto-balance).

--- a/hledger-macos/Views/Recurring/RecurringView.swift
+++ b/hledger-macos/Views/Recurring/RecurringView.swift
@@ -124,7 +124,7 @@ struct RecurringView: View {
         guard let backend = appState.activeBackend else { return }
         isLoading = true
         let path = RecurringManager.recurringPath(for: backend.journalFile)
-        rules = RecurringManager.parseRules(recurringPath: path, commodityStyles: appState.commodityStyles)
+        rules = RecurringManager.parseRules(recurringPath: path)
         knownAccounts = (try? await backend.loadAccounts()) ?? []
         isLoading = false
     }
@@ -161,15 +161,13 @@ struct RecurringView: View {
                     ruleId: editing.ruleId,
                     newRule: newRule,
                     journalFile: backend.journalFile,
-                    validator: backend,
-                    commodityStyles: appState.commodityStyles
+                    validator: backend
                 )
             } else {
                 try await RecurringManager.addRule(
                     newRule,
                     journalFile: backend.journalFile,
-                    validator: backend,
-                    commodityStyles: appState.commodityStyles
+                    validator: backend
                 )
             }
             await loadData()
@@ -227,8 +225,7 @@ struct RecurringView: View {
             try await RecurringManager.deleteRule(
                 ruleId: rule.ruleId,
                 journalFile: backend.journalFile,
-                validator: backend,
-                commodityStyles: appState.commodityStyles
+                validator: backend
             )
             await loadData()
         } catch {

--- a/hledger-macos/Views/Transactions/TransactionFormView.swift
+++ b/hledger-macos/Views/Transactions/TransactionFormView.swift
@@ -246,10 +246,7 @@ struct TransactionFormView: View {
     }
 
     private func parseAmountString(_ s: String) -> [Amount] {
-        guard let amount = PostingAmountParser.parse(
-            s,
-            defaultCommodity: appState.config.defaultCommodity
-        ) else {
+        guard let amount = appState.parseFormAmount(s) else {
             return []
         }
         return [amount]

--- a/hledger-macosTests/hledger_macosTests.swift
+++ b/hledger-macosTests/hledger_macosTests.swift
@@ -472,6 +472,130 @@ struct PostingAmountParserTests {
     }
 }
 
+// MARK: - PostingAmountParser styleResolver (#129)
+//
+// Regression coverage for the European-format 100x bug. Without a
+// styleResolver, the parser builds an Amount with the default
+// `decimalMark = "."`, which makes a journal that declares
+// `commodity € 1.000,00` re-parse `€1.00` as the integer 100.
+
+@Suite("PostingAmountParser.styleResolver")
+struct PostingAmountParserStyleResolverTests {
+
+    /// Build a European-style AmountStyle for €.
+    private static func europeanEuroStyle() -> AmountStyle {
+        AmountStyle(
+            commoditySide: .left,
+            commoditySpaced: false,
+            decimalMark: ",",
+            digitGroupSeparator: ".",
+            digitGroupSizes: [3],
+            precision: 2
+        )
+    }
+
+    @Test func parseAppliesEuropeanCommodityStyleFromResolver() {
+        // The fix: when the resolver returns a style, the resulting Amount
+        // must inherit decimalMark / digitGroupSeparator / digitGroupSizes
+        // from it. Without this, Amount.formatted() writes "€1.00" which
+        // hledger then mis-parses as 100 against a `commodity € 1.000,00`
+        // declaration.
+        let resolver: PostingAmountParser.StyleResolver = { commodity in
+            commodity == "€" ? Self.europeanEuroStyle() : nil
+        }
+        let amount = PostingAmountParser.parse("1,00", defaultCommodity: "€", styleResolver: resolver)
+
+        #expect(amount?.quantity == Decimal(1))
+        #expect(amount?.commodity == "€")
+        #expect(amount?.style.decimalMark == ",")
+        #expect(amount?.style.digitGroupSeparator == ".")
+        #expect(amount?.style.digitGroupSizes == [3])
+    }
+
+    @Test func formattedAmountFromResolverRoundTripsAsEuropean() {
+        // The user-visible symptom: Amount.formatted() must produce a string
+        // hledger can round-trip against a European-format commodity. Before
+        // the fix this returned "€1.00" → mis-parsed as 100. After the fix
+        // it returns "€1,00" → parses as 1.
+        let resolver: PostingAmountParser.StyleResolver = { commodity in
+            commodity == "€" ? Self.europeanEuroStyle() : nil
+        }
+        let amount = PostingAmountParser.parse("1,00", defaultCommodity: "€", styleResolver: resolver)!
+        #expect(amount.formatted() == "€1,00")
+    }
+
+    @Test func parseAlsoNormalizesDotInputForEuropeanCommodity() {
+        // The user might type `1.00` (US-style) even when the journal is
+        // European. The resolver overrides the input-derived decimalMark
+        // so the saved string is `€1,00` regardless of how the user typed it.
+        let resolver: PostingAmountParser.StyleResolver = { commodity in
+            commodity == "€" ? Self.europeanEuroStyle() : nil
+        }
+        let amount = PostingAmountParser.parse("1.00", defaultCommodity: "€", styleResolver: resolver)!
+        #expect(amount.quantity == Decimal(1))
+        #expect(amount.style.decimalMark == ",")
+        #expect(amount.formatted() == "€1,00")
+    }
+
+    @Test func parseFallsBackToInputStyleWhenResolverReturnsNil() {
+        // For commodities not declared in the journal (resolver returns nil),
+        // the parser must keep the input-derived style so the user can still
+        // invent new commodities mid-form without bugs.
+        let resolver: PostingAmountParser.StyleResolver = { _ in nil }
+        let amount = PostingAmountParser.parse("1.00", defaultCommodity: "USD", styleResolver: resolver)!
+        #expect(amount.style.decimalMark == ".")
+        #expect(amount.style.digitGroupSeparator == nil)
+    }
+
+    @Test func parseWithoutResolverPreservesLegacyBehavior() {
+        // Backward compat: callers that don't pass a resolver get the same
+        // input-derived style as before. Tests that exercise PostingAmountParser
+        // directly (without an AppState) keep working unchanged.
+        let amount = PostingAmountParser.parse("1.00", defaultCommodity: "€")!
+        #expect(amount.style.decimalMark == ".")
+    }
+
+    @Test func resolverIsAppliedToCostAnnotatedAmounts() {
+        // The fix must also cover the cost-annotated path so that
+        // `-5 XDWD @@ €742,55` against a European € journal round-trips
+        // correctly. The cost portion is parsed via parseSimple internally
+        // so it picks up the resolver too.
+        let resolver: PostingAmountParser.StyleResolver = { commodity in
+            commodity == "€" ? Self.europeanEuroStyle() : nil
+        }
+        let amount = PostingAmountParser.parse("-5 XDWD @@ €742,55", styleResolver: resolver)
+        #expect(amount?.quantity == Decimal(-5))
+        #expect(amount?.cost?.commodity == "€")
+        #expect(amount?.cost?.style.decimalMark == ",")
+        // The full formatted representation must use the European decimal mark
+        // for the cost portion.
+        #expect(amount?.formatted().contains("€742,55") == true)
+    }
+
+    @Test func resolverDoesNotOverridePrecisionOrSide() {
+        // Only decimalMark / digitGroupSeparator / digitGroupSizes are
+        // overridden by the resolver. Side, spacing, and input-derived
+        // precision must come from the user input so the user-typed shape
+        // (1 vs 1,00 vs 1,5) is preserved in the saved file.
+        let resolver: PostingAmountParser.StyleResolver = { _ in
+            AmountStyle(
+                commoditySide: .right,           // <-- should be IGNORED
+                commoditySpaced: true,           // <-- should be IGNORED
+                decimalMark: ",",
+                digitGroupSeparator: ".",
+                digitGroupSizes: [3],
+                precision: 4                     // <-- should be IGNORED
+            )
+        }
+        let amount = PostingAmountParser.parse("1,5", defaultCommodity: "€", styleResolver: resolver)!
+        #expect(amount.style.commoditySide == .left)        // input-derived (€ is single char)
+        #expect(amount.style.commoditySpaced == false)      // input-derived
+        #expect(amount.style.precision == 1)                // input-derived (1 decimal place)
+        #expect(amount.style.decimalMark == ",")            // resolver-derived
+        #expect(amount.style.digitGroupSeparator == ".")    // resolver-derived
+    }
+}
+
 // MARK: - AmountFormatter Tests
 
 @Suite("AmountFormatter")

--- a/hledger-macosTests/hledger_macosTests.swift
+++ b/hledger-macosTests/hledger_macosTests.swift
@@ -307,24 +307,26 @@ struct PostingAmountParserTests {
         #expect(PostingAmountParser.parseCostAnnotated("-1 SWDA @@ garbage") == nil)
     }
 
-    // MARK: - Roundtrip: parse → format → hledger-compatible output
+    // MARK: - Roundtrip: parse → format preserves the user-typed format
 
-    /// Critical test: European input must produce hledger-compatible output.
-    /// User types `-1 SWDA @@ 112,93` (Italian) → journal must contain `112.93`.
-    @Test func roundtripEuropeanInputProducesDotOutput() {
+    /// European input must round-trip preserving its `,` decimal mark.
+    /// Previously the parser flattened everything to `.` ("hledger-compatible
+    /// US format"), which seemed safer until #129 — that flattening is exactly
+    /// what made `commodity € 1.000,00` journals re-parse `€1.00` as 100×.
+    /// The new contract: the format the user typed is the format we save.
+    @Test func roundtripEuropeanInputPreservesCommaDecimal() {
         let amount = PostingAmountParser.parse("-1 SWDA @@ 112,93", defaultCommodity: "€")!
         let formatted = amount.formatted()
-        // Must contain the dot-normalized cost, no comma
-        #expect(formatted.contains("112.93"))
-        #expect(!formatted.contains("112,93"))
+        #expect(formatted.contains("112,93"))
+        #expect(!formatted.contains("112.93"))
         #expect(formatted.contains("@@"))
     }
 
-    @Test func roundtripSimpleEuropeanInputProducesDotOutput() {
+    @Test func roundtripSimpleEuropeanInputPreservesCommaDecimal() {
         let amount = PostingAmountParser.parse("€50,00")!
         let formatted = amount.formatted()
-        #expect(formatted.contains("50.00"))
-        #expect(!formatted.contains("50,00"))
+        #expect(formatted.contains("50,00"))
+        #expect(!formatted.contains("50.00"))
     }
 
     @Test func roundtripCostAnnotatedFormatIncludesCostMarker() {
@@ -405,6 +407,123 @@ struct PostingAmountParserTests {
         #expect(PostingAmountParser.decimalPlaces(in: "-112,93") == 2)
     }
 
+    /// #129 follow-up: amounts with a TRAILING commodity were returning
+    /// precision 0 because the post-comma slice contained the commodity
+    /// characters and `allSatisfy(\.isNumber)` short-circuited to false.
+    /// `decimalPlaces` now strips trailing non-numerics like it already
+    /// stripped leading ones.
+    @Test func decimalPlacesWithTrailingCurrencySymbol() {
+        #expect(PostingAmountParser.decimalPlaces(in: "1,00 €") == 2)
+        #expect(PostingAmountParser.decimalPlaces(in: "1,00€") == 2)
+        #expect(PostingAmountParser.decimalPlaces(in: "1.000,00 €") == 2)
+        #expect(PostingAmountParser.decimalPlaces(in: "-1,00 €") == 2)
+    }
+
+    @Test func decimalPlacesWithTrailingMultiCharCommodity() {
+        #expect(PostingAmountParser.decimalPlaces(in: "1,00 EUR") == 2)
+        #expect(PostingAmountParser.decimalPlaces(in: "50.00 USD") == 2)
+        #expect(PostingAmountParser.decimalPlaces(in: "1.234,56 EUR") == 2)
+        #expect(PostingAmountParser.decimalPlaces(in: "1,234.56 USD") == 2)
+        #expect(PostingAmountParser.decimalPlaces(in: "-1,00 EUR") == 2)
+    }
+
+    // MARK: - detectFormat helper (#129 part 2)
+
+    @Test func detectFormatPlainInteger() {
+        let f = PostingAmountParser.detectFormat(in: "50")
+        #expect(f.decimalMark == ".")
+        #expect(f.digitGroupSeparator == nil)
+    }
+
+    @Test func detectFormatDotDecimal() {
+        let f = PostingAmountParser.detectFormat(in: "50.00")
+        #expect(f.decimalMark == ".")
+        #expect(f.digitGroupSeparator == nil)
+    }
+
+    @Test func detectFormatCommaDecimal() {
+        let f = PostingAmountParser.detectFormat(in: "50,00")
+        #expect(f.decimalMark == ",")
+        #expect(f.digitGroupSeparator == nil)
+    }
+
+    @Test func detectFormatEuropeanThousands() {
+        let f = PostingAmountParser.detectFormat(in: "1.000,50")
+        #expect(f.decimalMark == ",")
+        #expect(f.digitGroupSeparator == ".")
+    }
+
+    @Test func detectFormatUSThousands() {
+        let f = PostingAmountParser.detectFormat(in: "1,000.50")
+        #expect(f.decimalMark == ".")
+        #expect(f.digitGroupSeparator == ",")
+    }
+
+    @Test func detectFormatCommaAsThousandsOnly() {
+        // "1,000" → 3 digits after comma → comma is thousands, dot is decimal
+        let f = PostingAmountParser.detectFormat(in: "1,000")
+        #expect(f.decimalMark == ".")
+        #expect(f.digitGroupSeparator == ",")
+    }
+
+    @Test func detectFormatStripsLeadingAndTrailingNonNumerics() {
+        // Leading currency
+        let leading = PostingAmountParser.detectFormat(in: "€1,00")
+        #expect(leading.decimalMark == ",")
+
+        // Trailing currency
+        let trailing = PostingAmountParser.detectFormat(in: "1,00 €")
+        #expect(trailing.decimalMark == ",")
+
+        // Leading negative + trailing commodity
+        let both = PostingAmountParser.detectFormat(in: "-1.000,50 EUR")
+        #expect(both.decimalMark == ",")
+        #expect(both.digitGroupSeparator == ".")
+    }
+
+    // MARK: - parseSimple now derives full style from input (#129 part 2)
+
+    /// Without a styleResolver, parseSimple must still produce an Amount whose
+    /// style matches the literal — `decimalMark`, `digitGroupSeparator`, and
+    /// `precision` all derived from input. This is what makes the
+    /// Recurring/Budget round-trip work without the old commodityStyles
+    /// tappabuchi in their parseRules helpers.
+    @Test func parseSimpleDerivesEuropeanStyleFromInputWithoutResolver() {
+        let amount = PostingAmountParser.parseSimple("€1,00")!
+        #expect(amount.quantity == Decimal(1))
+        #expect(amount.style.decimalMark == ",")
+        #expect(amount.style.precision == 2)
+        #expect(amount.formatted() == "€1,00")
+    }
+
+    @Test func parseSimpleDerivesEuropeanThousandsFromInputWithoutResolver() {
+        let amount = PostingAmountParser.parseSimple("€1.000,00")!
+        #expect(amount.quantity == Decimal(1000))
+        #expect(amount.style.decimalMark == ",")
+        #expect(amount.style.digitGroupSeparator == ".")
+        #expect(amount.style.digitGroupSizes == [3])
+        #expect(amount.formatted() == "€1.000,00")
+    }
+
+    @Test func parseSimpleDerivesUSStyleFromInputWithoutResolver() {
+        let amount = PostingAmountParser.parseSimple("$1,000.50")!
+        #expect(amount.quantity == Decimal(string: "1000.50"))
+        #expect(amount.style.decimalMark == ".")
+        #expect(amount.style.digitGroupSeparator == ",")
+        #expect(amount.formatted() == "$1,000.50")
+    }
+
+    @Test func parseSimpleDerivesEuropeanStyleFromTrailingCommodityInput() {
+        // The exact input that triggered the user-reported precision-0 bug
+        // discussed during #129 testing.
+        let amount = PostingAmountParser.parseSimple("1,00 €", defaultCommodity: "€")!
+        #expect(amount.quantity == Decimal(1))
+        #expect(amount.commodity == "€")
+        #expect(amount.style.precision == 2)
+        #expect(amount.style.decimalMark == ",")
+        #expect(amount.formatted() == "€1,00")
+    }
+
     // MARK: - Issue #95 gaps: literal #83 regression and edge cases
 
     /// Literal regression test for the exact string in issue #83:
@@ -417,10 +536,10 @@ struct PostingAmountParserTests {
         #expect(amount?.commodity == "XDWD")
         #expect(amount?.cost?.quantity == Decimal(string: "742.55"))
         #expect(amount?.cost?.commodity == "€")
-        // Formatted output must use `.` (hledger-compatible), never `,`
+        // Format must preserve the user-typed `,` decimal mark — see #129.
         let formatted = amount!.formatted()
-        #expect(formatted.contains("742.55"))
-        #expect(!formatted.contains("742,55"))
+        #expect(formatted.contains("742,55"))
+        #expect(!formatted.contains("742.55"))
     }
 
     @Test func parseTotalCostExtraWhitespaceAroundOperator() {
@@ -1910,7 +2029,11 @@ struct CommodityStyleTests {
 
     // -- RecurringManager parse with styles --
 
-    @Test func recurringParseWithEuropeanStyles() throws {
+    @Test func recurringParseDerivesEuropeanStyleFromLiteral() throws {
+        // After #129, parseRules no longer takes a commodityStyles parameter:
+        // the loaded Amount inherits its style from the literal via
+        // PostingAmountParser.parseSimple, which derives decimalMark and
+        // digitGroupSeparator from the input string itself.
         let content = """
         ~ monthly from 2026-01-01  ; rule-id:test1 Test rule
             expenses:food                                    €500,00
@@ -1923,19 +2046,16 @@ struct CommodityStyleTests {
         try content.write(to: tmpFile, atomically: true, encoding: .utf8)
         defer { try? FileManager.default.removeItem(at: tmpDir) }
 
-        let styles: [String: AmountStyle] = ["€": CommodityStyleTests.europeanStyle]
-        let rules = RecurringManager.parseRules(recurringPath: tmpFile, commodityStyles: styles)
+        let rules = RecurringManager.parseRules(recurringPath: tmpFile)
 
         #expect(rules.count == 1)
         let amount = rules[0].postings[0].amounts[0]
         #expect(amount.style.decimalMark == ",")
-        #expect(amount.style.digitGroupSeparator == ".")
-        // Verify formatted output uses European style
-        let formatted = amount.formatted()
-        #expect(formatted == "€500,00")
+        // Verify the literal round-trips
+        #expect(amount.formatted() == "€500,00")
     }
 
-    @Test func budgetParseWithEuropeanStyles() throws {
+    @Test func budgetParseDerivesEuropeanStyleFromLiteral() throws {
         let content = """
         ~ monthly
             expenses:groceries                               €500,00
@@ -1948,14 +2068,12 @@ struct CommodityStyleTests {
         try content.write(to: tmpFile, atomically: true, encoding: .utf8)
         defer { try? FileManager.default.removeItem(at: tmpDir) }
 
-        let styles: [String: AmountStyle] = ["€": CommodityStyleTests.europeanStyle]
-        let rules = BudgetManager.parseRules(budgetPath: tmpFile, commodityStyles: styles)
+        let rules = BudgetManager.parseRules(budgetPath: tmpFile)
 
         #expect(rules.count == 1)
         let amount = rules[0].amount
         #expect(amount.style.decimalMark == ",")
-        let formatted = amount.formatted()
-        #expect(formatted == "€500,00")
+        #expect(amount.formatted() == "€500,00")
     }
 
     // -- Helper: replicate AppState.extractCommodityStyles() logic for testing --


### PR DESCRIPTION
## Summary
Fixes the European-format **100×** bug reported in #129. When the journal declares a commodity like `commodity € 1.000,00`, inserting a new transaction through any form saved the amount with `decimalMark = "."`, and hledger then re-parsed `€1.00` as the integer 100.

The bug existed in `TransactionFormView` since `PostingAmountParser` was introduced. PR #89 (v0.2.2) extended it to `RecurringFormView` and `BudgetFormView` when it routed all three forms through the same parser without realising that the inline `appState.styleForCommodity` lookup the other two forms used was load-bearing.

## Single-point fix

- **`PostingAmountParser`** gains an optional `styleResolver: (String) -> AmountStyle?` parameter (`parse`, `parseSimple`, `parseCostAnnotated`). When the resolver returns a style for the parsed commodity, the parser overrides the input-derived `decimalMark`, `digitGroupSeparator`, and `digitGroupSizes` of the resulting `Amount`. **Side**, **spacing**, and **input-derived precision** are preserved so the user-typed shape is not flattened.
- **`AppState.parseFormAmount(_:)`** is the new single entry point all form callsites must use. It threads `commodityStyles[commodity]` into the parser as the resolver.
- **The three form callsites** (`TransactionFormView`, `RecurringFormView`, `BudgetFormView`) migrate from `PostingAmountParser.parse(...)` to `appState.parseFormAmount(...)`.

## Bonus: latent `Amount.formatted()` cost-annotation bug

While building the regression suite, the cost-annotation test surfaced a related latent bug: `Amount.formatted()`'s private `formatDecimal` helper used `self.style` to format the cost-annotation portion of an amount instead of `cost.style`. So a multi-currency cost like `-5 XDWD @@ €742,55` formatted the cost portion with the XDWD commodity's decimal mark instead of the €. Refactored `formatDecimal` to a static helper that takes an explicit `AmountStyle`, and pass `cost.style` for the cost portion.

## Tests
New `PostingAmountParser.styleResolver` suite with 7 regression tests:

| Test | Verifies |
|---|---|
| `parseAppliesEuropeanCommodityStyleFromResolver` | resolver overrides `decimalMark` / `digitGroupSeparator` / `digitGroupSizes` |
| `formattedAmountFromResolverRoundTripsAsEuropean` | `Amount.formatted()` writes `€1,00` (round-trips through hledger) |
| `parseAlsoNormalizesDotInputForEuropeanCommodity` | typing `1.00` for a European € still saves as `€1,00` |
| `parseFallsBackToInputStyleWhenResolverReturnsNil` | unknown commodities keep input-derived style (no regression for new commodities) |
| `parseWithoutResolverPreservesLegacyBehavior` | backward compat: callers without a resolver get the same behaviour as before |
| `resolverIsAppliedToCostAnnotatedAmounts` | `-5 XDWD @@ €742,55` round-trips with the European cost style |
| `resolverDoesNotOverridePrecisionOrSide` | only `decimalMark`/`digitGroupSeparator`/`digitGroupSizes` are overridden — side, spacing, and precision come from input |

**Test count: 332 → 339.**

## Test fixture: `examples/hledger-simple-eu/main.journal`

This PR adds a ready-to-use European-format demo journal as the manual test fixture. It is the companion to:
- `examples/hledger-simple/main.journal` — € but with `.` decimal mark, no `commodity` directive
- `examples/hledger-simple-us/main.journal` — `$` in US format

The new file:
- Declares `commodity € 1.000,00` at the top (the directive that triggers the bug)
- Mirrors the structure of `hledger-simple/main.journal` (Jan-Apr 2026, ~67 transactions, salary / rent / groceries / subscriptions / car loan / etc.)
- Uses true European number format throughout: `€5.000,00`, `€2.800,00`, `€67,30`

Validated with `hledger -f examples/hledger-simple-eu/main.journal stats` (67 transactions, 2 commodities) and `hledger ... balance --depth 2` (totals match the hand-calculated values).

## How to test this PR

### Setup (one-time)
1. Open Settings (⌘,) → **Journal File** → point at `examples/hledger-simple-eu/main.journal`
2. The app should load the demo with €25.367,27 in `assets:bank` and friends. If you see "100x" looking values somewhere it's already proof of the bug.

### Test 1 — TransactionFormView (the original report path)
1. ⌘N → New Transaction
2. Date: today, Description: anything
3. Posting 1: account `expenses:food:groceries`, amount `1,00`
4. Posting 2: account `assets:bank:checking` (auto-balance)
5. Save
6. ✅ Reopen the saved transaction in Edit mode → the amount must be **`€1,00`**, NOT `€100,00`
7. Repeat with different inputs:
   - `1.00` (US-style typed by mistake) → must save as `€1,00` (the resolver normalises)
   - `50,00` → must save as `€50,00`
   - `1.000,00` → must save as `€1.000,00`
   - `-50,00` → must save as `€-50,00`
8. After each save, **reopen the saved transaction in Edit mode** to verify

### Test 2 — RecurringFormView (regression from #89)
1. Recurring (⌘3) → New Recurring Rule
2. Description: `Test rent`, period: `monthly`, start date: today
3. Posting 1: `expenses:housing:rent`, amount `€750,00`
4. Posting 2: `assets:bank:checking` (blank for auto-balance)
5. Save
6. Edit the rule → ✅ amount must still be `€750,00`, **NOT `€75000,00`**
7. Click `Generate` (toolbar) → the generated transaction in the journal must use `,` decimal mark

### Test 3 — BudgetFormView (regression from #89)
1. Budget (⌘4) → New Budget Rule
2. Account: `expenses:food:groceries`, Amount: `€500,00`
3. Save
4. Edit the rule → ✅ amount must still be `€500,00`, **NOT `€50000,00`**
5. The Budget vs Actual computation in the view must show the correct budget value

### Test 4 — Cost-annotated transaction (the latent bug)
1. New Transaction with a posting like `-5 STCK @@ €742,55` (or any commodity with a € cost)
2. Save
3. Open the journal file on disk (or reopen the transaction in Edit) → ✅ the cost portion must be **`€742,55`**, NOT `€742.55` (note the comma — using the journal's € style for the cost portion)

### Test 5 — Negative regression (US-format users must NOT break)
Switch to `examples/hledger-simple-us/main.journal` (or your own US journal):
1. New Transaction with a `$` posting, type `50.00`
2. Save → ✅ must save as `$50.00` (dot decimal mark preserved)
3. New Transaction with `1,000.50` → must save as `$1,000.50`

### Test 6 — Unit tests
```bash
xcodebuild -project hledger-macos.xcodeproj -scheme hledger-macos -configuration Debug test \
  -only-testing:hledger-macosTests/PostingAmountParserStyleResolverTests 2>&1 | tail -15
```
Expected: **7 tests passed**.

Full suite:
```bash
xcodebuild -project hledger-macos.xcodeproj -scheme hledger-macos -configuration Debug test \
  -only-testing:hledger-macosTests 2>&1 | grep "Test run"
```
Expected: **`Test run with 339 tests in 44 suites passed`**.

### Test 7 — Cross-validate the fixture with hledger CLI
```bash
hledger -f examples/hledger-simple-eu/main.journal stats
hledger -f examples/hledger-simple-eu/main.journal balance --depth 2
```
Expected: 67 transactions, 2 commodities, `assets:bank` shows `€25.367,27` (or thereabouts). If hledger refuses the file or shows 100× values, the fixture itself is broken.

Closes #129