### PR TITLE
refactor: extract FormShellView and split TransactionFormView (#86, #92)

### DIFF
--- a/hledger-macos/Views/Budget/BudgetFormView.swift
+++ b/hledger-macos/Views/Budget/BudgetFormView.swift
@@ -20,67 +20,33 @@ struct BudgetFormView: View {
     private var title: String { isEditing ? "Edit Budget Rule" : "New Budget Rule" }
 
     var body: some View {
-        VStack(spacing: 0) {
-            ScrollView {
-                VStack(alignment: .leading, spacing: 0) {
-                    // Title
-                    HStack {
-                        Spacer()
-                        Text(title)
-                            .font(.headline)
-                            .foregroundStyle(Color.accentColor)
-                        Spacer()
-                    }
-                    .padding(.top, Theme.Spacing.xl)
-                    .padding(.bottom, Theme.Spacing.xl)
-
-                    // Fields
-                    VStack(spacing: 14) {
-                        FormRow("Account:") {
-                            AutocompleteField(
-                                placeholder: "e.g. expenses:groceries",
-                                text: $account,
-                                suggestions: knownAccounts
-                            )
-                        }
-
-                        FormRow("Amount:") {
-                            TextField("e.g. 500.00", text: $amount)
-                                .textFieldStyle(.roundedBorder)
-                        }
-
-                        FormRow("Category:") {
-                            TextField("e.g. Food, Housing (optional)", text: $category)
-                                .textFieldStyle(.roundedBorder)
-                        }
-                    }
-                    .padding(.horizontal, Theme.Spacing.xxl)
-                }
-            }
-
-            Divider()
-
-            // Footer
-            HStack {
-                if let error = errorMessage {
-                    Text(error)
-                        .font(.caption)
-                        .foregroundStyle(.red)
-                        .lineLimit(2)
+        FormShellView(
+            title: title,
+            errorMessage: errorMessage,
+            saveDisabled: account.isEmpty || amount.isEmpty,
+            onCancel: { dismiss() },
+            onSave: { save() }
+        ) {
+            VStack(spacing: 14) {
+                FormRow("Account:") {
+                    AutocompleteField(
+                        placeholder: "e.g. expenses:groceries",
+                        text: $account,
+                        suggestions: knownAccounts
+                    )
                 }
 
-                Spacer()
+                FormRow("Amount:") {
+                    TextField("e.g. 500.00", text: $amount)
+                        .textFieldStyle(.roundedBorder)
+                }
 
-                Button("Cancel") { dismiss() }
-                    .keyboardShortcut(.cancelAction)
-
-                Button("Save") { save() }
-                    .buttonStyle(.borderedProminent)
-                    .keyboardShortcut(.defaultAction)
-                    .disabled(account.isEmpty || amount.isEmpty)
+                FormRow("Category:") {
+                    TextField("e.g. Food, Housing (optional)", text: $category)
+                        .textFieldStyle(.roundedBorder)
+                }
             }
             .padding(.horizontal, Theme.Spacing.xxl)
-            .padding(.vertical, Theme.Spacing.md)
         }
         .frame(width: 480, height: 300)
         .onAppear { prefill() }

--- a/hledger-macos/Views/Recurring/RecurringFormView.swift
+++ b/hledger-macos/Views/Recurring/RecurringFormView.swift
@@ -26,110 +26,77 @@ struct RecurringFormView: View {
     private var title: String { isEditing ? "Edit Recurring Rule" : "New Recurring Rule" }
 
     var body: some View {
-        VStack(spacing: 0) {
-            ScrollView {
-                VStack(alignment: .leading, spacing: 0) {
-                    // Title
+        FormShellView(
+            title: title,
+            errorMessage: errorMessage,
+            saveDisabled: description.isEmpty || startYear.isEmpty,
+            onCancel: { dismiss() },
+            onSave: { save() }
+        ) {
+            // Fields
+            VStack(spacing: 14) {
+                FormRow("Period:") {
                     HStack {
-                        Spacer()
-                        Text(title)
-                            .font(.headline)
-                            .foregroundStyle(Color.accentColor)
-                        Spacer()
-                    }
-                    .padding(.top, Theme.Spacing.xl)
-                    .padding(.bottom, Theme.Spacing.xl)
-
-                    // Fields
-                    VStack(spacing: 14) {
-                        FormRow("Period:") {
-                            HStack {
-                                Picker("", selection: $periodExpr) {
-                                    ForEach(RecurringManager.supportedPeriods, id: \.self) { period in
-                                        Text(period.capitalized).tag(period)
-                                    }
-                                }
-                                .labelsHidden()
-                                .fixedSize()
-                                Spacer()
+                        Picker("", selection: $periodExpr) {
+                            ForEach(RecurringManager.supportedPeriods, id: \.self) { period in
+                                Text(period.capitalized).tag(period)
                             }
                         }
-
-                        FormRow("Description:") {
-                            TextField("Recurring transaction description", text: $description)
-                                .textFieldStyle(.roundedBorder)
-                        }
-
-                        FormRow("Start date:") {
-                            DateInputField(year: $startYear, month: $startMonth, day: $startDay)
-                        }
-
-                        FormRow("End date:") {
-                            DateInputField(year: $endYear, month: $endMonth, day: $endDay, optional: true)
-                        }
+                        .labelsHidden()
+                        .fixedSize()
+                        Spacer()
                     }
-                    .padding(.horizontal, Theme.Spacing.xxl)
-
-                    // Postings
-                    VStack(alignment: .leading, spacing: 8) {
-                        Divider().padding(.vertical, Theme.Spacing.md)
-
-                        Text("Postings")
-                            .font(.subheadline.bold())
-
-                        Text("Leave one amount blank for auto-balance.")
-                            .font(.caption)
-                            .foregroundStyle(.secondary)
-                            .padding(.bottom, Theme.Spacing.sm)
-
-                        ForEach(Array(postingRows.enumerated()), id: \.element.id) { index, _ in
-                            PostingRowField(
-                                index: index,
-                                account: $postingRows[index].account,
-                                amount: $postingRows[index].amount,
-                                comment: .constant(""),
-                                suggestions: knownAccounts,
-                                showRemove: postingRows.count > 2,
-                                onRemove: { postingRows.remove(at: index) }
-                            )
-                        }
-
-                        Button {
-                            postingRows.append(PostingRow())
-                        } label: {
-                            Label("Add Posting", systemImage: "plus")
-                        }
-                        .controlSize(.small)
-                        .padding(.top, Theme.Spacing.xs)
-                    }
-                    .padding(.horizontal, Theme.Spacing.xxl)
-                    .padding(.bottom, Theme.Spacing.lg)
-                }
-            }
-
-            Divider()
-
-            // Footer
-            HStack {
-                if let error = errorMessage {
-                    Text(error)
-                        .font(.caption)
-                        .foregroundStyle(.red)
-                        .lineLimit(2)
                 }
 
-                Spacer()
+                FormRow("Description:") {
+                    TextField("Recurring transaction description", text: $description)
+                        .textFieldStyle(.roundedBorder)
+                }
 
-                Button("Cancel") { dismiss() }
-                    .keyboardShortcut(.cancelAction)
+                FormRow("Start date:") {
+                    DateInputField(year: $startYear, month: $startMonth, day: $startDay)
+                }
 
-                Button("Save") { save() }
-                    .buttonStyle(.borderedProminent)
-                    .keyboardShortcut(.defaultAction)
-                    .disabled(description.isEmpty || startYear.isEmpty)
+                FormRow("End date:") {
+                    DateInputField(year: $endYear, month: $endMonth, day: $endDay, optional: true)
+                }
             }
             .padding(.horizontal, Theme.Spacing.xxl)
-            .padding(.vertical, Theme.Spacing.md)
+
+            // Postings
+            VStack(alignment: .leading, spacing: 8) {
+                Divider().padding(.vertical, Theme.Spacing.md)
+
+                Text("Postings")
+                    .font(.subheadline.bold())
+
+                Text("Leave one amount blank for auto-balance.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .padding(.bottom, Theme.Spacing.sm)
+
+                ForEach(Array(postingRows.enumerated()), id: \.element.id) { index, _ in
+                    PostingRowField(
+                        index: index,
+                        account: $postingRows[index].account,
+                        amount: $postingRows[index].amount,
+                        comment: .constant(""),
+                        suggestions: knownAccounts,
+                        showRemove: postingRows.count > 2,
+                        onRemove: { postingRows.remove(at: index) }
+                    )
+                }
+
+                Button {
+                    postingRows.append(PostingRow())
+                } label: {
+                    Label("Add Posting", systemImage: "plus")
+                }
+                .controlSize(.small)
+                .padding(.top, Theme.Spacing.xs)
+            }
+            .padding(.horizontal, Theme.Spacing.xxl)
+            .padding(.bottom, Theme.Spacing.lg)
         }
         .frame(width: 560, height: 520)
         .onAppear { prefill() }

--- a/hledger-macos/Views/Shared/FormShellView.swift
+++ b/hledger-macos/Views/Shared/FormShellView.swift
@@ -1,0 +1,81 @@
+/// Reusable form shell layout for transaction-style forms.
+///
+/// Provides a centered title (inside the scrolling area), a scrollable content
+/// region, a divider, and a footer with an optional error message + Cancel /
+/// Save buttons. The frame size is set by the caller via `.frame()` on the
+/// result so the three forms (Transaction, Recurring, Budget) can keep their
+/// own dimensions.
+///
+/// Used by TransactionFormView, RecurringFormView, and BudgetFormView. See #86.
+
+import SwiftUI
+
+struct FormShellView<Content: View>: View {
+    let title: String
+    let errorMessage: String?
+    let saveDisabled: Bool
+    let onCancel: () -> Void
+    let onSave: () -> Void
+    let content: () -> Content
+
+    init(
+        title: String,
+        errorMessage: String? = nil,
+        saveDisabled: Bool = false,
+        onCancel: @escaping () -> Void,
+        onSave: @escaping () -> Void,
+        @ViewBuilder content: @escaping () -> Content
+    ) {
+        self.title = title
+        self.errorMessage = errorMessage
+        self.saveDisabled = saveDisabled
+        self.onCancel = onCancel
+        self.onSave = onSave
+        self.content = content
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            ScrollView {
+                VStack(alignment: .leading, spacing: 0) {
+                    // Centered title
+                    HStack {
+                        Spacer()
+                        Text(title)
+                            .font(.headline)
+                            .foregroundStyle(Color.accentColor)
+                        Spacer()
+                    }
+                    .padding(.top, Theme.Spacing.xl)
+                    .padding(.bottom, Theme.Spacing.xl)
+
+                    content()
+                }
+            }
+
+            Divider()
+
+            // Footer
+            HStack {
+                if let error = errorMessage {
+                    Text(error)
+                        .font(.caption)
+                        .foregroundStyle(.red)
+                        .lineLimit(2)
+                }
+
+                Spacer()
+
+                Button("Cancel", action: onCancel)
+                    .keyboardShortcut(.cancelAction)
+
+                Button("Save", action: onSave)
+                    .buttonStyle(.borderedProminent)
+                    .keyboardShortcut(.defaultAction)
+                    .disabled(saveDisabled)
+            }
+            .padding(.horizontal, Theme.Spacing.xxl)
+            .padding(.vertical, Theme.Spacing.md)
+        }
+    }
+}

--- a/hledger-macos/Views/Transactions/TransactionFormContent.swift
+++ b/hledger-macos/Views/Transactions/TransactionFormContent.swift
@@ -1,0 +1,101 @@
+/// Inner form body for `TransactionFormView` — the fields and postings
+/// area that lives inside the `FormShellView`'s scroll content. Holds the
+/// `@FocusState` for the Code / Comment text fields (which can't live in
+/// `TransactionFormState` because `@FocusState` requires a SwiftUI view
+/// context). See #92.
+
+import SwiftUI
+
+struct TransactionFormContent: View {
+    @Bindable var state: TransactionFormState
+    let defaultCommodity: String
+
+    @FocusState private var focusedField: Field?
+
+    private enum Field: Hashable {
+        case code, comment
+    }
+
+    var body: some View {
+        // Fields
+        VStack(spacing: 14) {
+            FormRow("Date:") {
+                DateInputField(year: $state.dateYear, month: $state.dateMonth, day: $state.dateDay)
+            }
+
+            FormRow("Description:") {
+                AutocompleteField(
+                    placeholder: "Transaction description",
+                    text: $state.description,
+                    suggestions: state.knownDescriptions
+                )
+            }
+
+            FormRow("Status:") {
+                HStack {
+                    Picker("", selection: $state.status) {
+                        Text("Unmarked").tag(TransactionStatus.unmarked)
+                        Text("Pending").tag(TransactionStatus.pending)
+                        Text("Cleared").tag(TransactionStatus.cleared)
+                    }
+                    .labelsHidden()
+                    .fixedSize()
+                    Spacer()
+                }
+            }
+
+            FormRow("Code:") {
+                TextField("Optional transaction code", text: $state.code)
+                    .textFieldStyle(.roundedBorder)
+                    .focused($focusedField, equals: .code)
+            }
+
+            FormRow("Comment:") {
+                TextField("Optional comment", text: $state.comment)
+                    .textFieldStyle(.roundedBorder)
+                    .focused($focusedField, equals: .comment)
+            }
+        }
+        .padding(.horizontal, Theme.Spacing.xxl)
+
+        // Postings
+        VStack(alignment: .leading, spacing: 8) {
+            Divider().padding(.vertical, Theme.Spacing.md)
+
+            Text("Postings")
+                .font(.subheadline.bold())
+
+            Text("Amount: plain number (50.00), currency prefix (\(defaultCommodity)50.00), or commodity with cost (-5 STCK @@ \(defaultCommodity)200.00). Leave one amount blank to auto-balance.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .padding(.bottom, Theme.Spacing.xs)
+
+            Text("Default commodity: \(defaultCommodity)")
+                .font(.caption.italic())
+                .foregroundStyle(.tertiary)
+                .padding(.bottom, Theme.Spacing.sm)
+
+            ForEach(Array(state.postingRows.enumerated()), id: \.element.id) { index, _ in
+                PostingRowField(
+                    index: index,
+                    account: $state.postingRows[index].account,
+                    amount: $state.postingRows[index].amount,
+                    comment: $state.postingRows[index].comment,
+                    suggestions: state.knownAccounts,
+                    showRemove: state.postingRows.count > 2,
+                    onRemove: { state.postingRows.remove(at: index) }
+                )
+            }
+
+            Button {
+                state.postingRows.append(PostingRow())
+            } label: {
+                Label("Add Posting", systemImage: "plus")
+            }
+            .controlSize(.small)
+            .padding(.top, Theme.Spacing.xs)
+        }
+        .padding(.horizontal, Theme.Spacing.xxl)
+        .padding(.bottom, Theme.Spacing.lg)
+    }
+}

--- a/hledger-macos/Views/Transactions/TransactionFormState.swift
+++ b/hledger-macos/Views/Transactions/TransactionFormState.swift
@@ -1,0 +1,175 @@
+/// Observable state and logic for `TransactionFormView`.
+///
+/// Split out from the view so the form data, prefill, validation, and save
+/// flow can be reasoned about (and tested) independently of the SwiftUI
+/// body. The view keeps focus state, dismiss, and the FormShellView wiring;
+/// everything else lives here. See #92.
+
+import SwiftUI
+
+@MainActor
+@Observable
+final class TransactionFormState {
+
+    // MARK: - Identity (set at init)
+
+    let editingTransaction: Transaction?
+    let isClone: Bool
+
+    // MARK: - Form data
+
+    var dateYear = ""
+    var dateMonth = ""
+    var dateDay = ""
+    var description = ""
+    var status: TransactionStatus = .unmarked
+    var code = ""
+    var comment = ""
+    var postingRows: [PostingRow] = []
+
+    // MARK: - Save flow state
+
+    var isSaving = false
+    var errorMessage: String?
+
+    // MARK: - Autocomplete data
+
+    var knownAccounts: [String] = []
+    var knownDescriptions: [String] = []
+
+    init(editingTransaction: Transaction?, isClone: Bool) {
+        self.editingTransaction = editingTransaction
+        self.isClone = isClone
+    }
+
+    // MARK: - Computed
+
+    var isEditing: Bool { editingTransaction != nil && !isClone }
+
+    var title: String {
+        if isClone { return "Clone Transaction" }
+        if isEditing { return "Edit Transaction" }
+        return "New Transaction"
+    }
+
+    var dateString: String {
+        "\(dateYear)-\(dateMonth)-\(dateDay)"
+    }
+
+    var isDateValid: Bool {
+        guard dateYear.count == 4, dateMonth.count == 2, dateDay.count == 2 else { return false }
+        let f = DateFormatter()
+        f.dateFormat = "yyyy-MM-dd"
+        return f.date(from: dateString) != nil
+    }
+
+    // MARK: - Prefill
+
+    func prefill() {
+        if let txn = editingTransaction {
+            let parts = (isClone ? "" : txn.date).split(separator: "-").map(String.init)
+            dateYear = parts.count > 0 ? parts[0] : ""
+            dateMonth = parts.count > 1 ? parts[1] : ""
+            dateDay = parts.count > 2 ? parts[2] : ""
+            description = txn.description
+            status = txn.status
+            code = txn.code
+            comment = txn.comment
+            postingRows = txn.postings.map {
+                PostingRow(
+                    account: $0.account,
+                    amount: $0.amounts.first.map { $0.formatted() } ?? "",
+                    comment: $0.comment,
+                    balanceAssertion: $0.balanceAssertion
+                )
+            }
+        }
+
+        while postingRows.count < 2 { postingRows.append(PostingRow()) }
+
+        if dateYear.isEmpty && editingTransaction == nil {
+            let f = DateFormatter()
+            f.dateFormat = "yyyy"
+            dateYear = f.string(from: Date())
+            f.dateFormat = "MM"
+            dateMonth = f.string(from: Date())
+            f.dateFormat = "dd"
+            dateDay = f.string(from: Date())
+        }
+    }
+
+    // MARK: - Autocomplete
+
+    func loadAutocompleteData(from backend: (any AccountingBackend)?) async {
+        guard let backend else { return }
+        knownAccounts = (try? await backend.loadAccounts()) ?? []
+        knownDescriptions = (try? await backend.loadDescriptions()) ?? []
+    }
+
+    // MARK: - Save
+
+    /// Persist the current form state to the journal.
+    ///
+    /// - Returns: `true` if the save succeeded — the caller should dismiss
+    ///   the form. `false` if it failed; `errorMessage` is set to the failure
+    ///   reason and the form should remain visible.
+    func save(using appState: AppState) async -> Bool {
+        guard let backend = appState.activeBackend else { return false }
+        isSaving = true
+        errorMessage = nil
+
+        var postings: [Posting] = []
+        for row in postingRows where !row.account.isEmpty {
+            postings.append(Posting(
+                account: row.account,
+                amounts: parseAmountString(row.amount, using: appState),
+                comment: row.comment,
+                balanceAssertion: row.balanceAssertion
+            ))
+        }
+
+        // hledger accepts transactions with 0 postings.
+
+        let newTransaction = Transaction(
+            index: 0,
+            date: dateString,
+            description: description,
+            postings: postings,
+            status: status,
+            code: code,
+            comment: comment
+        )
+
+        do {
+            if isEditing, let original = editingTransaction {
+                try await backend.replaceTransaction(original, with: newTransaction)
+            } else {
+                try await backend.appendTransaction(newTransaction)
+            }
+            isSaving = false
+            Task { await appState.reloadAfterWrite() }
+            return true
+        } catch {
+            errorMessage = error.localizedDescription
+            isSaving = false
+            return false
+        }
+    }
+
+    private func parseAmountString(_ s: String, using appState: AppState) -> [Amount] {
+        guard let amount = appState.parseFormAmount(s) else { return [] }
+        return [amount]
+    }
+}
+
+// MARK: - PostingRow
+
+/// One row in the postings table of a transaction form. Lives next to the
+/// state because the state owns `[PostingRow]` and the row IS form data.
+struct PostingRow: Identifiable {
+    let id = UUID()
+    var account: String = ""
+    var amount: String = ""
+    var comment: String = ""
+    var balanceAssertion: String = ""
+}

--- a/hledger-macos/Views/Transactions/TransactionFormView.swift
+++ b/hledger-macos/Views/Transactions/TransactionFormView.swift
@@ -1,4 +1,8 @@
 /// Sheet for creating, editing, or cloning a transaction.
+///
+/// Thin wrapper around `FormShellView` and `TransactionFormContent`. The
+/// form data and save/validation logic live in `TransactionFormState`.
+/// See #86 (FormShellView extraction) and #92 (this view's split).
 
 import SwiftUI
 
@@ -9,254 +13,38 @@ struct TransactionFormView: View {
     let editingTransaction: Transaction?
     let isClone: Bool
 
-    @State private var dateYear = ""
-    @State private var dateMonth = ""
-    @State private var dateDay = ""
-    @State private var description = ""
-    @State private var status: TransactionStatus = .unmarked
-    @State private var code = ""
-    @State private var comment = ""
-    @State private var postingRows: [PostingRow] = []
-    @State private var isSaving = false
-    @State private var errorMessage: String?
-    @State private var knownAccounts: [String] = []
-    @State private var knownDescriptions: [String] = []
+    @State private var formState: TransactionFormState
 
-    @FocusState private var focusedField: Field?
-
-    private enum Field: Hashable {
-        case code, comment
-        case postingAccount(Int), postingAmount(Int)
-    }
-
-    private var isEditing: Bool { editingTransaction != nil && !isClone }
-
-    private var title: String {
-        if isClone { return "Clone Transaction" }
-        if isEditing { return "Edit Transaction" }
-        return "New Transaction"
-    }
-
-    private var dateString: String {
-        "\(dateYear)-\(dateMonth)-\(dateDay)"
-    }
-
-    private var isDateValid: Bool {
-        guard dateYear.count == 4, dateMonth.count == 2, dateDay.count == 2 else { return false }
-        let f = DateFormatter()
-        f.dateFormat = "yyyy-MM-dd"
-        return f.date(from: dateString) != nil
+    init(editingTransaction: Transaction?, isClone: Bool) {
+        self.editingTransaction = editingTransaction
+        self.isClone = isClone
+        self._formState = State(initialValue: TransactionFormState(
+            editingTransaction: editingTransaction,
+            isClone: isClone
+        ))
     }
 
     var body: some View {
-        VStack(spacing: 0) {
-            ScrollView {
-                VStack(alignment: .leading, spacing: 0) {
-                    // Title
-                    HStack {
-                        Spacer()
-                        Text(title)
-                            .font(.headline)
-                            .foregroundStyle(Color.accentColor)
-                        Spacer()
-                    }
-                    .padding(.top, Theme.Spacing.xl)
-                    .padding(.bottom, Theme.Spacing.xl)
-
-                    // Fields
-                    VStack(spacing: 14) {
-                        FormRow("Date:") {
-                            DateInputField(year: $dateYear, month: $dateMonth, day: $dateDay)
-                        }
-
-                        FormRow("Description:") {
-                            AutocompleteField(
-                                placeholder: "Transaction description",
-                                text: $description,
-                                suggestions: knownDescriptions
-                            )
-                        }
-
-                        FormRow("Status:") {
-                            HStack {
-                                Picker("", selection: $status) {
-                                    Text("Unmarked").tag(TransactionStatus.unmarked)
-                                    Text("Pending").tag(TransactionStatus.pending)
-                                    Text("Cleared").tag(TransactionStatus.cleared)
-                                }
-                                .labelsHidden()
-                                .fixedSize()
-                                Spacer()
-                            }
-                        }
-
-                        FormRow("Code:") {
-                            TextField("Optional transaction code", text: $code)
-                                .textFieldStyle(.roundedBorder)
-                                .focused($focusedField, equals: .code)
-                        }
-
-                        FormRow("Comment:") {
-                            TextField("Optional comment", text: $comment)
-                                .textFieldStyle(.roundedBorder)
-                                .focused($focusedField, equals: .comment)
-                        }
-                    }
-                    .padding(.horizontal, Theme.Spacing.xxl)
-
-                    // Postings
-                    VStack(alignment: .leading, spacing: 8) {
-                        Divider().padding(.vertical, Theme.Spacing.md)
-
-                        Text("Postings")
-                            .font(.subheadline.bold())
-
-                        Text("Amount: plain number (50.00), currency prefix (\(appState.config.defaultCommodity)50.00), or commodity with cost (-5 STCK @@ \(appState.config.defaultCommodity)200.00). Leave one amount blank to auto-balance.")
-                            .font(.caption)
-                            .foregroundStyle(.secondary)
-                            .padding(.bottom, Theme.Spacing.xs)
-
-                        Text("Default commodity: \(appState.config.defaultCommodity)")
-                            .font(.caption.italic())
-                            .foregroundStyle(.tertiary)
-                            .padding(.bottom, Theme.Spacing.sm)
-
-                        ForEach(Array(postingRows.enumerated()), id: \.element.id) { index, _ in
-                            PostingRowField(
-                                index: index,
-                                account: $postingRows[index].account,
-                                amount: $postingRows[index].amount,
-                                comment: $postingRows[index].comment,
-                                suggestions: knownAccounts,
-                                showRemove: postingRows.count > 2,
-                                onRemove: { postingRows.remove(at: index) }
-                            )
-                        }
-
-                        Button {
-                            postingRows.append(PostingRow())
-                        } label: {
-                            Label("Add Posting", systemImage: "plus")
-                        }
-                        .controlSize(.small)
-                        .padding(.top, Theme.Spacing.xs)
-                    }
-                    .padding(.horizontal, Theme.Spacing.xxl)
-                    .padding(.bottom, Theme.Spacing.lg)
-                }
-            }
-
-            Divider()
-
-            // Footer
-            HStack {
-                if let error = errorMessage {
-                    Text(error)
-                        .font(.caption)
-                        .foregroundStyle(.red)
-                        .lineLimit(2)
-                }
-
-                Spacer()
-
-                Button("Cancel") { dismiss() }
-                    .keyboardShortcut(.cancelAction)
-
-                Button("Save") { Task { await save() } }
-                    .buttonStyle(.borderedProminent)
-                    .keyboardShortcut(.defaultAction)
-                    .disabled(isSaving || !isDateValid)
-            }
-            .padding(.horizontal, Theme.Spacing.xxl)
-            .padding(.vertical, Theme.Spacing.md)
+        FormShellView(
+            title: formState.title,
+            errorMessage: formState.errorMessage,
+            saveDisabled: formState.isSaving || !formState.isDateValid,
+            onCancel: { dismiss() },
+            onSave: { Task { await performSave() } }
+        ) {
+            TransactionFormContent(
+                state: formState,
+                defaultCommodity: appState.config.defaultCommodity
+            )
         }
         .frame(width: 560, height: 580)
-        .task { await loadAutocompleteData() }
-        .onAppear { prefill() }
+        .task { await formState.loadAutocompleteData(from: appState.activeBackend) }
+        .onAppear { formState.prefill() }
     }
 
-    // MARK: - Prefill
-
-    private func prefill() {
-        if let txn = editingTransaction {
-            let parts = (isClone ? "" : txn.date).split(separator: "-").map(String.init)
-            dateYear = parts.count > 0 ? parts[0] : ""
-            dateMonth = parts.count > 1 ? parts[1] : ""
-            dateDay = parts.count > 2 ? parts[2] : ""
-            description = txn.description
-            status = txn.status
-            code = txn.code
-            comment = txn.comment
-            postingRows = txn.postings.map { PostingRow(account: $0.account, amount: $0.amounts.first.map { $0.formatted() } ?? "", comment: $0.comment, balanceAssertion: $0.balanceAssertion) }
-        }
-
-        while postingRows.count < 2 { postingRows.append(PostingRow()) }
-
-        if dateYear.isEmpty && editingTransaction == nil {
-            let f = DateFormatter()
-            f.dateFormat = "yyyy"
-            dateYear = f.string(from: Date())
-            f.dateFormat = "MM"
-            dateMonth = f.string(from: Date())
-            f.dateFormat = "dd"
-            dateDay = f.string(from: Date())
-        }
-    }
-
-    // MARK: - Autocomplete
-
-    private func loadAutocompleteData() async {
-        guard let backend = appState.activeBackend else { return }
-        knownAccounts = (try? await backend.loadAccounts()) ?? []
-        knownDescriptions = (try? await backend.loadDescriptions()) ?? []
-    }
-
-    // MARK: - Save
-
-    private func save() async {
-        guard let backend = appState.activeBackend else { return }
-        isSaving = true
-        errorMessage = nil
-
-        var postings: [Posting] = []
-        for row in postingRows where !row.account.isEmpty {
-            postings.append(Posting(account: row.account, amounts: parseAmountString(row.amount), comment: row.comment, balanceAssertion: row.balanceAssertion))
-        }
-
-        // hledger accepts transactions with 0 postings
-
-        let newTransaction = Transaction(
-            index: 0, date: dateString, description: description,
-            postings: postings, status: status, code: code, comment: comment
-        )
-
-        do {
-            if isEditing, let original = editingTransaction {
-                try await backend.replaceTransaction(original, with: newTransaction)
-            } else {
-                try await backend.appendTransaction(newTransaction)
-            }
+    private func performSave() async {
+        if await formState.save(using: appState) {
             dismiss()
-            Task { await appState.reloadAfterWrite() }
-        } catch {
-            errorMessage = error.localizedDescription
         }
-
-        isSaving = false
     }
-
-    private func parseAmountString(_ s: String) -> [Amount] {
-        guard let amount = appState.parseFormAmount(s) else {
-            return []
-        }
-        return [amount]
-    }
-}
-
-struct PostingRow: Identifiable {
-    let id = UUID()
-    var account: String = ""
-    var amount: String = ""
-    var comment: String = ""
-    var balanceAssertion: String = ""
 }


### PR DESCRIPTION
## Summary
Closes **two** structural-refactor issues for v0.2.3 in one PR because #92 explicitly says it depends on #86 ("*may be done together*").

> ⚠️ This branch is **stacked on #142** (the #129 European-format bug fix). It includes that fix as a base commit so you can test this PR in isolation without the 100× bug interfering. Merge order should be: **#142 first**, then this PR rebases cleanly onto main and merges.

### #86 — FormShellView extraction
The three transaction-style forms (Transaction, Recurring, Budget) duplicated the same outer shell: a `VStack(spacing: 0)` containing a `ScrollView` with a centered title, a `Divider`, and a footer with an optional error message + Cancel/Save buttons.

Extracted into `Views/Shared/FormShellView.swift` with a clean API:
\`\`\`swift
FormShellView(
    title: String,
    errorMessage: String? = nil,
    saveDisabled: Bool = false,
    onCancel: () -> Void,
    onSave: () -> Void,
    @ViewBuilder content: () -> Content
)
\`\`\`

The frame size stays on the caller (each form has a different preferred size) and so do `task` / `onAppear` modifiers, since they attach to the form-specific lifecycle.

Migrated all three forms. **Visual appearance is unchanged.**

### #92 — Split TransactionFormView
\`TransactionFormView\` was 265 lines mixing form state, prefill, validation, save logic, autocomplete loading, and the SwiftUI body. Split into **three files**:

| File | Role |
|---|---|
| \`TransactionFormState.swift\` | \`@MainActor @Observable final class\` with all form data, prefill, computed validation (\`title\`, \`dateString\`, \`isDateValid\`), \`loadAutocompleteData\`, and \`save(using:) async -> Bool\`. \`PostingRow\` lives here too. |
| \`TransactionFormContent.swift\` | Inner form body (FormRow stack + Postings VStack) bound to the state via \`@Bindable\`. Holds the \`@FocusState\` for Code / Comment fields (can't live on the state because \`@FocusState\` requires a SwiftUI view context). |
| \`TransactionFormView.swift\` | Thin 50-line wrapper that creates the state, wires it into \`FormShellView\`, and handles \`dismiss()\` after a successful save. |

The save flow previously called \`dismiss()\` directly from inside \`save()\` (only possible from a view). The state now returns \`Bool\` and the view dismisses on \`true\`.

## Metrics

| File | Before | After | Δ |
|---|---|---|---|
| \`TransactionFormView.swift\` | 265 | **50** | −215 |
| \`TransactionFormState.swift\` | — | 175 (new) | +175 |
| \`TransactionFormContent.swift\` | — | 101 (new) | +101 |
| \`RecurringFormView.swift\` | 209 | 173 | −36 |
| \`BudgetFormView.swift\` | 118 | 81 | −37 |
| \`FormShellView.swift\` | — | 81 (new) | +81 |
| **Total** | **592** | **661** | **+69** |

The total ticks up because each PR introduces shared infrastructure that pays off the next time someone adds a form. The duplication itself is gone.

\`TransactionFormView\` main view: **265 → 50 lines** (the issue target was ~150, easily met).

## Test plan

Both refactors are pure structural moves — there should be **no observable behavior change**. The 339-test suite still passes.

### How to test #86 — FormShellView (3 forms still work)

1. Open the app on this branch
2. **Transaction form**:
   - ⌘N → New Transaction
   - ✅ The sheet renders with the same title (centered, accent color), the same form fields, the same footer (Cancel + Save buttons)
   - Type valid data → Save button enables
   - Click Save → form dismisses, transaction appears in the list
   - Open an existing transaction with Edit (⌘E from the list) → ✅ same shell, prefilled data
   - Open with Clone (⌘D) → ✅ same shell, date cleared, other fields prefilled
3. **Recurring form**:
   - Recurring view (⌘3) → New Recurring Rule
   - ✅ Same shell appearance (different size: 560×520, vs Transaction's 560×580)
   - Save / Cancel work
   - Edit an existing rule → ✅ shell + prefill work
4. **Budget form**:
   - Budget view (⌘4) → New Budget Rule
   - ✅ Same shell appearance (smallest size: 480×300)
   - Save / Cancel work
   - Edit an existing rule → ✅ shell + prefill work
5. **Visual regression check**: open each form alongside the same form on \`main\` (or compare with screenshots) — there must be **zero pixel difference**.

### How to test #92 — TransactionFormView split

1. Same as #86 Transaction form tests above (the user-visible behavior must be identical)
2. **Specific things to verify** (paths that the split touched):
   - **Date prefill**: ⌘N opens with today's date
   - **Date prefill on Edit**: opens with the transaction's date
   - **Date prefill on Clone**: opens with empty date
   - **Date validation**: an invalid date (e.g. month 13) disables Save and shows the red ✗ indicator
   - **Save button enabled state**: \`isSaving || !isDateValid\` — should match \`main\`
   - **Autocomplete**: typing in the Description field shows suggestions from previous descriptions
   - **Account autocomplete** in postings: typing an account name shows suggestions
   - **Posting row management**: Add Posting button works, Remove (when ≥3 postings) works
   - **Auto-balance**: leave one posting amount blank → on save, hledger auto-balances
   - **Status picker**: Unmarked / Pending / Cleared all work
   - **Code and Comment fields**: typing focuses correctly (no focus glitches)
   - **Error path**: cause a save failure (e.g. invalid posting like negative-without-currency) → \`errorMessage\` shows in the footer, the form does NOT dismiss
   - **Success path**: a valid transaction → form dismisses, list refreshes
3. **Edge cases**:
   - Cancel button on a half-filled form → no transaction is saved
   - Save with all fields filled correctly → transaction appears in the list with the right values
   - **Sub-bonus**: this branch also includes #129's fix (PR #142). If you have a European-format journal (\`commodity € 1.000,00\`), test that amounts round-trip correctly: type \`50,00\` for an € posting → saves as \`€50,00\`, NOT \`€5000,00\`.

### Unit tests
\`\`\`bash
xcodebuild -project hledger-macos.xcodeproj -scheme hledger-macos \\
  -configuration Debug test -only-testing:hledger-macosTests 2>&1 | grep "Test run"
\`\`\`
Expected: **\`Test run with 339 tests in 44 suites passed\`**.

(No new tests were added for #86/#92 because they are pure structural refactors with no new logic to cover. The existing 339-test suite is the regression net.)

Closes #86
Closes #92