### PR TITLE
chore: bump version to 0.2.3

### DIFF
--- a/hledger-macos.xcodeproj/project.pbxproj
+++ b/hledger-macos.xcodeproj/project.pbxproj
@@ -414,7 +414,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 0.2.2;
+				MARKETING_VERSION = 0.2.3;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.thesmokinator.hledger-macos";
 				PRODUCT_NAME = "hledger for Mac";
 				REGISTER_APP_GROUPS = YES;
@@ -448,7 +448,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 0.2.2;
+				MARKETING_VERSION = 0.2.3;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.thesmokinator.hledger-macos";
 				PRODUCT_NAME = "hledger for Mac";
 				REGISTER_APP_GROUPS = YES;


### PR DESCRIPTION
Bump \`MARKETING_VERSION\` from \`0.2.2\` to \`0.2.3\` in both Debug and Release configurations of the hledger-macos target.

## v0.2.3 milestone summary

3 PRs merged for v0.2.3 (one bug fix + two structural refactors):

### #142 — fix: respect commodity AmountStyle when parsing form input (closes #129)
The European-format **100×** bug. \`PostingAmountParser\` now derives the full \`AmountStyle\` from the input literal (\`decimalMark\`, \`digitGroupSeparator\`, \`digitGroupSizes\`, \`precision\`), and \`AppState.parseFormAmount(_:)\` is the new single entry point that all form callsites use. The existing tappabuchi in \`RecurringManager.parseRules\` and \`BudgetManager.parseRules\` (which masked precision-loss on reload via \`commodityStyles[commodity] ?? .default\`) has been removed — both managers now go through \`PostingAmountParser.parseSimple\`, the same path as form input.

Bonus latent fix: \`Amount.formatted()\`'s private \`formatDecimal\` helper used \`self.style\` for the cost-annotation portion instead of \`cost.style\`, refactored to a static helper that takes an explicit \`AmountStyle\`.

Includes \`examples/hledger-simple-eu/main.journal\` as a manual test fixture (full demo journal in true European format, validated with hledger CLI).

### #143 — refactor: extract FormShellView and split TransactionFormView (closes #86, #92)
The three transaction-style forms (Transaction, Recurring, Budget) duplicated the same outer shell. Extracted into \`Views/Shared/FormShellView.swift\`. \`TransactionFormView\` was 265 lines mixing form state, prefill, validation, save logic, autocomplete loading, and the SwiftUI body — split into:
- \`TransactionFormState.swift\` — \`@MainActor @Observable final class\` with all data and logic
- \`TransactionFormContent.swift\` — inner form body bound via \`@Bindable\`
- \`TransactionFormView.swift\` — thin 50-line wrapper

\`TransactionFormView\`: **265 → 50 lines** (target was ~150).

## Test count: 332 → 352

This PR is the prerequisite for the \`v0.2.3\` tag — once merged, the tag will be created from \`main\` and CI will handle the release per the project workflow.

## New issue spawned during this milestone
- thesmokinator/hledger-macos#144 — \`refactor: extract generic RuleFileManager protocol from BudgetManager / RecurringManager\` (backlog, no milestone yet) — duplication observed during the #129 work