### PR TITLE
refactor: extract generic RuleFileManager from BudgetManager / RecurringManager

### DIFF
--- a/hledger-macos/Backend/BudgetManager.swift
+++ b/hledger-macos/Backend/BudgetManager.swift
@@ -1,52 +1,35 @@
 /// Budget file management: read/write periodic transactions in budget.journal.
 ///
 /// Ported from hledger-textual/budget.py.
+///
+/// `BudgetRuleFile` implements the `RuleFile` protocol with the budget-specific
+/// parse/format logic and key (`account`).  All shared file workflow is handled
+/// by `RuleFileManager<BudgetRuleFile>`.
+/// `BudgetManager` is a thin wrapper that preserves the existing public API.
 
 import Foundation
 
-enum BudgetManager {
-    static let budgetFilename = "budget.journal"
+// MARK: - BudgetRuleFile
 
-    // MARK: - File Path
+enum BudgetRuleFile: RuleFile {
+    typealias Rule = BudgetRule
+    typealias Key = String
 
-    /// Path to budget.journal next to the main journal.
-    static func budgetPath(for journalFile: URL) -> URL {
-        journalFile.deletingLastPathComponent().appendingPathComponent(budgetFilename)
+    static let filename = "budget.journal"
+
+    static func key(of rule: BudgetRule) -> String { rule.account }
+
+    static func duplicateError(_ key: String) -> BackendError {
+        .commandFailed("Budget rule already exists for \(key)")
     }
 
-    // MARK: - Ensure File Exists
-
-    /// Create budget.journal if missing and add include directive to main journal.
-    static func ensureBudgetFile(journalFile: URL) throws {
-        let budgetFile = budgetPath(for: journalFile)
-
-        if !FileManager.default.fileExists(atPath: budgetFile.path) {
-            try "".write(to: budgetFile, atomically: true, encoding: .utf8)
-        }
-
-        var journalText = try String(contentsOf: journalFile, encoding: .utf8)
-        let includePattern = /^\s*include\s+budget\.journal\s*$/
-        let hasInclude = journalText.split(separator: "\n").contains { line in
-            line.wholeMatch(of: includePattern) != nil
-        }
-
-        if !hasInclude {
-            let includeLine = "include \(budgetFilename)\n\n"
-            journalText = includeLine + journalText
-            try journalText.write(to: journalFile, atomically: true, encoding: .utf8)
-        }
+    static func notFoundError(_ key: String) -> BackendError {
+        .commandFailed("No budget rule found for \(key)")
     }
 
-    // MARK: - Parse Rules
+    // MARK: Parse
 
-    /// Parse budget rules from budget.journal.
-    static func parseRules(budgetPath: URL) -> [BudgetRule] {
-        guard FileManager.default.fileExists(atPath: budgetPath.path),
-              let content = try? String(contentsOf: budgetPath, encoding: .utf8),
-              !content.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
-            return []
-        }
-
+    static func parseRules(from content: String) -> [BudgetRule] {
         var rules: [BudgetRule] = []
         var inPeriodic = false
         let periodicPattern = /^~\s+\S/
@@ -60,9 +43,7 @@ enum BudgetManager {
             }
 
             if inPeriodic {
-                if !line.isEmpty && !line.first!.isWhitespace {
-                    break
-                }
+                if !line.isEmpty && !line.first!.isWhitespace { break }
                 if line.firstMatch(of: balancingPattern) != nil { continue }
                 if line.trimmingCharacters(in: .whitespaces).isEmpty { continue }
 
@@ -74,11 +55,7 @@ enum BudgetManager {
                     // full style (decimalMark, digitGroupSeparator, precision)
                     // from the literal — same path as form input. See #129.
                     if let amount = PostingAmountParser.parseSimple(amountStr) {
-                        rules.append(BudgetRule(
-                            account: account,
-                            amount: amount,
-                            category: category
-                        ))
+                        rules.append(BudgetRule(account: account, amount: amount, category: category))
                     }
                 }
             }
@@ -87,9 +64,8 @@ enum BudgetManager {
         return rules
     }
 
-    // MARK: - Format Rules
+    // MARK: Format
 
-    /// Format budget rules into budget.journal content.
     static func formatRules(_ rules: [BudgetRule]) -> String {
         guard !rules.isEmpty else { return "" }
 
@@ -111,65 +87,60 @@ enum BudgetManager {
         lines.append("")
         return lines.joined(separator: "\n")
     }
+}
 
-    // MARK: - Write Rules
+// MARK: - BudgetManager (public API wrapper)
 
-    /// Write budget rules with backup/validate/restore.
-    static func writeRules(_ rules: [BudgetRule], budgetPath: URL, journalFile: URL, validator: any AccountingBackend) async throws {
-        let backup = budgetPath.appendingPathExtension("bak")
-        if FileManager.default.fileExists(atPath: budgetPath.path) {
-            try FileManager.default.copyItem(at: budgetPath, to: backup)
-        }
+/// Thin wrapper around `RuleFileManager<BudgetRuleFile>` that preserves the
+/// original `BudgetManager` call surface used by views and tests.
+enum BudgetManager {
 
-        do {
-            let content = formatRules(rules)
-            try content.write(to: budgetPath, atomically: true, encoding: .utf8)
-            try await validator.validateJournal()
-            try? FileManager.default.removeItem(at: backup)
-        } catch {
-            if FileManager.default.fileExists(atPath: backup.path) {
-                try? FileManager.default.removeItem(at: budgetPath)
-                try? FileManager.default.moveItem(at: backup, to: budgetPath)
-            }
-            try? FileManager.default.removeItem(at: backup)
-            throw BackendError.journalValidationFailed("Budget validation failed: \(error.localizedDescription)")
-        }
+    // MARK: File path
+
+    static func budgetPath(for journalFile: URL) -> URL {
+        RuleFileManager<BudgetRuleFile>.filePath(for: journalFile)
     }
 
-    // MARK: - CRUD
+    // MARK: Ensure file exists
 
-    /// Add a new budget rule.
+    static func ensureBudgetFile(journalFile: URL) throws {
+        try RuleFileManager<BudgetRuleFile>.ensureFile(journalFile: journalFile)
+    }
+
+    // MARK: Parse / format
+
+    static func parseRules(budgetPath: URL) -> [BudgetRule] {
+        RuleFileManager<BudgetRuleFile>.parseRules(at: budgetPath)
+    }
+
+    static func formatRules(_ rules: [BudgetRule]) -> String {
+        RuleFileManager<BudgetRuleFile>.formatRules(rules)
+    }
+
+    // MARK: Write
+
+    static func writeRules(
+        _ rules: [BudgetRule],
+        budgetPath: URL,
+        journalFile: URL,
+        validator: any AccountingBackend
+    ) async throws {
+        try await RuleFileManager<BudgetRuleFile>.writeRules(
+            rules, to: budgetPath, journalFile: journalFile, validator: validator
+        )
+    }
+
+    // MARK: CRUD
+
     static func addRule(_ rule: BudgetRule, journalFile: URL, validator: any AccountingBackend) async throws {
-        let path = budgetPath(for: journalFile)
-        try ensureBudgetFile(journalFile: journalFile)
-        var rules = parseRules(budgetPath: path)
-        if rules.contains(where: { $0.account == rule.account }) {
-            throw BackendError.commandFailed("Budget rule already exists for \(rule.account)")
-        }
-        rules.append(rule)
-        try await writeRules(rules, budgetPath: path, journalFile: journalFile, validator: validator)
+        try await RuleFileManager<BudgetRuleFile>.addRule(rule, journalFile: journalFile, validator: validator)
     }
 
-    /// Update an existing budget rule.
     static func updateRule(oldAccount: String, newRule: BudgetRule, journalFile: URL, validator: any AccountingBackend) async throws {
-        let path = budgetPath(for: journalFile)
-        var rules = parseRules(budgetPath: path)
-        guard let index = rules.firstIndex(where: { $0.account == oldAccount }) else {
-            throw BackendError.commandFailed("No budget rule found for \(oldAccount)")
-        }
-        rules[index] = newRule
-        try await writeRules(rules, budgetPath: path, journalFile: journalFile, validator: validator)
+        try await RuleFileManager<BudgetRuleFile>.updateRule(key: oldAccount, newRule: newRule, journalFile: journalFile, validator: validator)
     }
 
-    /// Delete a budget rule by account name.
     static func deleteRule(account: String, journalFile: URL, validator: any AccountingBackend) async throws {
-        let path = budgetPath(for: journalFile)
-        var rules = parseRules(budgetPath: path)
-        let count = rules.count
-        rules.removeAll { $0.account == account }
-        if rules.count == count {
-            throw BackendError.commandFailed("No budget rule found for \(account)")
-        }
-        try await writeRules(rules, budgetPath: path, journalFile: journalFile, validator: validator)
+        try await RuleFileManager<BudgetRuleFile>.deleteRule(key: account, journalFile: journalFile, validator: validator)
     }
 }

--- a/hledger-macos/Backend/RecurringManager.swift
+++ b/hledger-macos/Backend/RecurringManager.swift
@@ -1,52 +1,36 @@
 /// Recurring transactions file management: read/write periodic rules in recurring.journal.
 ///
 /// Ported from hledger-textual/recurring.py.
+///
+/// `RecurringRuleFile` implements the `RuleFile` protocol with the recurring-specific
+/// parse/format logic and key (`ruleId`).  All shared file workflow is handled
+/// by `RuleFileManager<RecurringRuleFile>`.
+/// `RecurringManager` is a thin wrapper that preserves the existing public API
+/// and also provides the transaction-generation helpers unique to recurring rules.
 
 import Foundation
 
-enum RecurringManager {
-    static let recurringFilename = "recurring.journal"
+// MARK: - RecurringRuleFile
 
-    static let supportedPeriods = [
-        "daily", "weekly", "biweekly", "monthly", "bimonthly", "quarterly", "yearly"
-    ]
+enum RecurringRuleFile: RuleFile {
+    typealias Rule = RecurringRule
+    typealias Key = String
 
-    // MARK: - File Path
+    static let filename = "recurring.journal"
 
-    static func recurringPath(for journalFile: URL) -> URL {
-        journalFile.deletingLastPathComponent().appendingPathComponent(recurringFilename)
+    static func key(of rule: RecurringRule) -> String { rule.ruleId }
+
+    static func duplicateError(_ key: String) -> BackendError {
+        .commandFailed("Recurring rule already exists with id: \(key)")
     }
 
-    // MARK: - Ensure File Exists
-
-    static func ensureRecurringFile(journalFile: URL) throws {
-        let recurringFile = recurringPath(for: journalFile)
-
-        if !FileManager.default.fileExists(atPath: recurringFile.path) {
-            try "".write(to: recurringFile, atomically: true, encoding: .utf8)
-        }
-
-        var journalText = try String(contentsOf: journalFile, encoding: .utf8)
-        let hasInclude = journalText.split(separator: "\n").contains { line in
-            line.trimmingCharacters(in: .whitespaces).hasPrefix("include \(recurringFilename)")
-        }
-
-        if !hasInclude {
-            let includeLine = "include \(recurringFilename)\n\n"
-            journalText = includeLine + journalText
-            try journalText.write(to: journalFile, atomically: true, encoding: .utf8)
-        }
+    static func notFoundError(_ key: String) -> BackendError {
+        .commandFailed("No recurring rule found with id: \(key)")
     }
 
-    // MARK: - Parse Rules
+    // MARK: Parse
 
-    static func parseRules(recurringPath: URL) -> [RecurringRule] {
-        guard FileManager.default.fileExists(atPath: recurringPath.path),
-              let content = try? String(contentsOf: recurringPath, encoding: .utf8),
-              !content.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
-            return []
-        }
-
+    static func parseRules(from content: String) -> [RecurringRule] {
         let headerPattern = /^~\s+(\S+)(?:\s+from\s+(\d{4}-\d{2}-\d{2}))?(?:\s+to\s+(\d{4}-\d{2}-\d{2}))?\s*(?:;\s*rule-id:(\S+)(?:\s+(.+))?)?\s*$/
         let postingPattern = /^\s{4,}(\S.+?)\s{2,}(\S+)\s*$/
 
@@ -102,7 +86,6 @@ enum RecurringManager {
                         currentPostings.append(Posting(account: account))
                     }
                 } else {
-                    // Balancing posting (no amount)
                     let account = line.trimmingCharacters(in: .whitespaces)
                     if !account.isEmpty {
                         currentPostings.append(Posting(account: account))
@@ -115,7 +98,7 @@ enum RecurringManager {
         return rules
     }
 
-    // MARK: - Format Rules
+    // MARK: Format
 
     static func formatRules(_ rules: [RecurringRule]) -> String {
         guard !rules.isEmpty else { return "" }
@@ -150,65 +133,70 @@ enum RecurringManager {
 
         return blocks.joined(separator: "\n\n") + "\n"
     }
+}
 
-    // MARK: - Write Rules
+// MARK: - RecurringManager (public API wrapper)
 
-    static func writeRules(_ rules: [RecurringRule], recurringPath: URL, journalFile: URL, validator: any AccountingBackend) async throws {
-        let backup = recurringPath.appendingPathExtension("bak")
-        if FileManager.default.fileExists(atPath: recurringPath.path) {
-            try FileManager.default.copyItem(at: recurringPath, to: backup)
-        }
+/// Thin wrapper around `RuleFileManager<RecurringRuleFile>` that preserves the
+/// original `RecurringManager` call surface used by views and tests.
+/// Transaction-generation helpers (`generateOccurrences`, `computePending`,
+/// `generateTransactions`) are unique to recurring rules and remain here.
+enum RecurringManager {
 
-        do {
-            let content = formatRules(rules)
-            try content.write(to: recurringPath, atomically: true, encoding: .utf8)
-            try await validator.validateJournal()
-            try? FileManager.default.removeItem(at: backup)
-        } catch {
-            if FileManager.default.fileExists(atPath: backup.path) {
-                try? FileManager.default.removeItem(at: recurringPath)
-                try? FileManager.default.moveItem(at: backup, to: recurringPath)
-            }
-            try? FileManager.default.removeItem(at: backup)
-            throw BackendError.journalValidationFailed("Recurring validation failed: \(error.localizedDescription)")
-        }
+    static let supportedPeriods = [
+        "daily", "weekly", "biweekly", "monthly", "bimonthly", "quarterly", "yearly"
+    ]
+
+    // MARK: File path
+
+    static func recurringPath(for journalFile: URL) -> URL {
+        RuleFileManager<RecurringRuleFile>.filePath(for: journalFile)
     }
 
-    // MARK: - CRUD
+    // MARK: Ensure file exists
+
+    static func ensureRecurringFile(journalFile: URL) throws {
+        try RuleFileManager<RecurringRuleFile>.ensureFile(journalFile: journalFile)
+    }
+
+    // MARK: Parse / format
+
+    static func parseRules(recurringPath: URL) -> [RecurringRule] {
+        RuleFileManager<RecurringRuleFile>.parseRules(at: recurringPath)
+    }
+
+    static func formatRules(_ rules: [RecurringRule]) -> String {
+        RuleFileManager<RecurringRuleFile>.formatRules(rules)
+    }
+
+    // MARK: Write
+
+    static func writeRules(
+        _ rules: [RecurringRule],
+        recurringPath: URL,
+        journalFile: URL,
+        validator: any AccountingBackend
+    ) async throws {
+        try await RuleFileManager<RecurringRuleFile>.writeRules(
+            rules, to: recurringPath, journalFile: journalFile, validator: validator
+        )
+    }
+
+    // MARK: CRUD
 
     static func addRule(_ rule: RecurringRule, journalFile: URL, validator: any AccountingBackend) async throws {
-        let path = recurringPath(for: journalFile)
-        try ensureRecurringFile(journalFile: journalFile)
-        var rules = parseRules(recurringPath: path)
-        if rules.contains(where: { $0.ruleId == rule.ruleId }) {
-            throw BackendError.commandFailed("Recurring rule already exists with id: \(rule.ruleId)")
-        }
-        rules.append(rule)
-        try await writeRules(rules, recurringPath: path, journalFile: journalFile, validator: validator)
+        try await RuleFileManager<RecurringRuleFile>.addRule(rule, journalFile: journalFile, validator: validator)
     }
 
     static func updateRule(ruleId: String, newRule: RecurringRule, journalFile: URL, validator: any AccountingBackend) async throws {
-        let path = recurringPath(for: journalFile)
-        var rules = parseRules(recurringPath: path)
-        guard let index = rules.firstIndex(where: { $0.ruleId == ruleId }) else {
-            throw BackendError.commandFailed("No recurring rule found with id: \(ruleId)")
-        }
-        rules[index] = newRule
-        try await writeRules(rules, recurringPath: path, journalFile: journalFile, validator: validator)
+        try await RuleFileManager<RecurringRuleFile>.updateRule(key: ruleId, newRule: newRule, journalFile: journalFile, validator: validator)
     }
 
     static func deleteRule(ruleId: String, journalFile: URL, validator: any AccountingBackend) async throws {
-        let path = recurringPath(for: journalFile)
-        var rules = parseRules(recurringPath: path)
-        let count = rules.count
-        rules.removeAll { $0.ruleId == ruleId }
-        if rules.count == count {
-            throw BackendError.commandFailed("No recurring rule found with id: \(ruleId)")
-        }
-        try await writeRules(rules, recurringPath: path, journalFile: journalFile, validator: validator)
+        try await RuleFileManager<RecurringRuleFile>.deleteRule(key: ruleId, journalFile: journalFile, validator: validator)
     }
 
-    // MARK: - Transaction Generation
+    // MARK: Transaction Generation
 
     /// Generate occurrence dates for a rule from start to today.
     static func generateOccurrences(start: Date, period: String, end: Date) -> [Date] {
@@ -274,7 +262,6 @@ enum RecurringManager {
 
         let allDates = generateOccurrences(start: start, period: rule.periodExpr, end: end)
 
-        // Load already-generated transactions tagged with this rule's ID
         let generated: [Transaction]
         do {
             generated = try await backend.loadTransactions(query: "tag:rule-id=\(rule.ruleId)", reversed: false)

--- a/hledger-macos/Backend/RuleFile.swift
+++ b/hledger-macos/Backend/RuleFile.swift
@@ -1,0 +1,165 @@
+/// Generic protocol and manager for hledger rule files (budget.journal, recurring.journal).
+///
+/// `RuleFile` captures what is unique to each file type: its filename on disk,
+/// how to parse and format rules, which field acts as the business key, and the
+/// error messages to produce when a duplicate or missing key is encountered.
+///
+/// `RuleFileManager<F>` provides the shared file workflow that was previously
+/// duplicated between BudgetManager and RecurringManager:
+/// - ensure the file exists and the include directive is present in the main journal
+/// - atomic backup → write → validate → rollback-on-failure
+/// - add / update / delete wrappers around the write workflow
+
+import Foundation
+
+// MARK: - RuleFile protocol
+
+protocol RuleFile {
+    associatedtype Rule
+    associatedtype Key: Equatable
+
+    static var filename: String { get }
+
+    /// Parse rules from the raw text content of the rule file.
+    static func parseRules(from content: String) -> [Rule]
+
+    /// Serialise rules back to the rule file text content.
+    static func formatRules(_ rules: [Rule]) -> String
+
+    /// Extract the business key from a rule (used for duplicate detection and lookup).
+    static func key(of rule: Rule) -> Key
+
+    static func duplicateError(_ key: Key) -> BackendError
+    static func notFoundError(_ key: Key) -> BackendError
+}
+
+// MARK: - RuleFileManager
+
+/// Generic file manager that implements the shared workflow for any `RuleFile`.
+enum RuleFileManager<F: RuleFile> {
+
+    // MARK: File path
+
+    static func filePath(for journalFile: URL) -> URL {
+        journalFile.deletingLastPathComponent().appendingPathComponent(F.filename)
+    }
+
+    // MARK: Ensure file exists
+
+    /// Create the rule file if it is missing and prepend an include directive to
+    /// the main journal if one is not already present.
+    static func ensureFile(journalFile: URL) throws {
+        let file = filePath(for: journalFile)
+
+        if !FileManager.default.fileExists(atPath: file.path) {
+            try "".write(to: file, atomically: true, encoding: .utf8)
+        }
+
+        var journalText = try String(contentsOf: journalFile, encoding: .utf8)
+        let hasInclude = journalText.split(separator: "\n").contains {
+            $0.trimmingCharacters(in: .whitespaces).hasPrefix("include \(F.filename)")
+        }
+
+        if !hasInclude {
+            journalText = "include \(F.filename)\n\n" + journalText
+            try journalText.write(to: journalFile, atomically: true, encoding: .utf8)
+        }
+    }
+
+    // MARK: Parse / format
+
+    /// Read and parse rules from a rule file at the given path.
+    static func parseRules(at filePath: URL) -> [F.Rule] {
+        guard FileManager.default.fileExists(atPath: filePath.path),
+              let content = try? String(contentsOf: filePath, encoding: .utf8),
+              !content.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            return []
+        }
+        return F.parseRules(from: content)
+    }
+
+    /// Serialise rules to text (delegates to the concrete `RuleFile` type).
+    static func formatRules(_ rules: [F.Rule]) -> String {
+        F.formatRules(rules)
+    }
+
+    // MARK: Atomic write with validation
+
+    /// Write rules atomically: backup → write → validate journal → remove backup.
+    /// Rolls back to the backup if validation fails.
+    static func writeRules(
+        _ rules: [F.Rule],
+        to filePath: URL,
+        journalFile: URL,
+        validator: any AccountingBackend
+    ) async throws {
+        let backup = filePath.appendingPathExtension("bak")
+        if FileManager.default.fileExists(atPath: filePath.path) {
+            try FileManager.default.copyItem(at: filePath, to: backup)
+        }
+
+        do {
+            let content = F.formatRules(rules)
+            try content.write(to: filePath, atomically: true, encoding: .utf8)
+            try await validator.validateJournal()
+            try? FileManager.default.removeItem(at: backup)
+        } catch {
+            if FileManager.default.fileExists(atPath: backup.path) {
+                try? FileManager.default.removeItem(at: filePath)
+                try? FileManager.default.moveItem(at: backup, to: filePath)
+            }
+            try? FileManager.default.removeItem(at: backup)
+            throw BackendError.journalValidationFailed(
+                "\(F.filename) validation failed: \(error.localizedDescription)"
+            )
+        }
+    }
+
+    // MARK: CRUD
+
+    static func addRule(
+        _ rule: F.Rule,
+        journalFile: URL,
+        validator: any AccountingBackend
+    ) async throws {
+        try ensureFile(journalFile: journalFile)
+        let path = filePath(for: journalFile)
+        var rules = parseRules(at: path)
+        let k = F.key(of: rule)
+        if rules.contains(where: { F.key(of: $0) == k }) {
+            throw F.duplicateError(k)
+        }
+        rules.append(rule)
+        try await writeRules(rules, to: path, journalFile: journalFile, validator: validator)
+    }
+
+    static func updateRule(
+        key: F.Key,
+        newRule: F.Rule,
+        journalFile: URL,
+        validator: any AccountingBackend
+    ) async throws {
+        let path = filePath(for: journalFile)
+        var rules = parseRules(at: path)
+        guard let index = rules.firstIndex(where: { F.key(of: $0) == key }) else {
+            throw F.notFoundError(key)
+        }
+        rules[index] = newRule
+        try await writeRules(rules, to: path, journalFile: journalFile, validator: validator)
+    }
+
+    static func deleteRule(
+        key: F.Key,
+        journalFile: URL,
+        validator: any AccountingBackend
+    ) async throws {
+        let path = filePath(for: journalFile)
+        var rules = parseRules(at: path)
+        let count = rules.count
+        rules.removeAll { F.key(of: $0) == key }
+        if rules.count == count {
+            throw F.notFoundError(key)
+        }
+        try await writeRules(rules, to: path, journalFile: journalFile, validator: validator)
+    }
+}

--- a/hledger-macosTests/RuleFileManagerTests.swift
+++ b/hledger-macosTests/RuleFileManagerTests.swift
@@ -1,0 +1,287 @@
+import Testing
+import Foundation
+@testable import hledger_for_Mac
+
+// MARK: - Test helpers
+
+fileprivate enum RFMHelpers {
+    static func makeTempDir() throws -> URL {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("RuleFileManagerTests-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        return dir
+    }
+
+    static func writeFile(_ content: String, in dir: URL, name: String) throws -> URL {
+        let url = dir.appendingPathComponent(name)
+        try content.write(to: url, atomically: true, encoding: .utf8)
+        return url
+    }
+
+    static func makeBudgetRule(account: String = "expenses:food", amount: String = "500.00") -> BudgetRule {
+        BudgetRule(
+            account: account,
+            amount: Amount(commodity: "€", quantity: Decimal(string: amount)!)
+        )
+    }
+}
+
+/// Backend that always passes validation.
+fileprivate struct PassingBackend: AccountingBackend {
+    var binaryPath: String { "/usr/bin/hledger" }
+    var journalFile: URL { URL(fileURLWithPath: "/tmp/test.journal") }
+    func validateJournal() async throws {}
+    func version() async throws -> String { "1.0" }
+    func loadTransactions(query: String?, reversed: Bool) async throws -> [Transaction] { [] }
+    func loadDescriptions() async throws -> [String] { [] }
+    func loadAccounts() async throws -> [String] { [] }
+    func loadAccountBalances() async throws -> [(String, String)] { [] }
+    func loadAccountTreeBalances() async throws -> [AccountNode] { [] }
+    func loadCommodities() async throws -> [String] { [] }
+    func loadJournalStats() async throws -> JournalStats { JournalStats(transactionCount: 0, accountCount: 0, commodities: []) }
+    func loadPeriodSummary(period: String?) async throws -> PeriodSummary { PeriodSummary(income: 0, expenses: 0, commodity: "€") }
+    func loadExpenseBreakdown(period: String?, preferredCommodity: String) async throws -> [(String, Decimal, String)] { [] }
+    func loadIncomeBreakdown(period: String?, preferredCommodity: String) async throws -> [(String, Decimal, String)] { [] }
+    func loadLiabilitiesBreakdown(preferredCommodity: String) async throws -> [(String, Decimal, String)] { [] }
+    func loadAssetsBreakdown(preferredCommodity: String) async throws -> [(String, Decimal, String)] { [] }
+    func loadMultiCurrencyAccounts() async throws -> Set<String> { [] }
+    func loadInvestmentPositions() async throws -> [(String, Decimal, String)] { [] }
+    func loadInvestmentCost() async throws -> [String: (Decimal, String)] { [:] }
+    func loadInvestmentMarketValues(pricesFile: URL) async throws -> [String: (Decimal, String)] { [:] }
+    func loadReport(type: ReportType, periodBegin: String?, periodEnd: String?, commodity: String?) async throws -> ReportData { ReportData(title: "") }
+    func loadBudgetReport(period: String) async throws -> [BudgetRow] { [] }
+    func parseCsvImport(csvFile: URL, rulesFile: URL) async throws -> [Transaction] { [] }
+    func validateCsvRules(csvFile: URL, rulesFile: URL) async throws {}
+    func appendTransaction(_ transaction: Transaction) async throws {}
+    func updateTransactionStatus(_ transaction: Transaction, to newStatus: TransactionStatus) async throws {}
+    func replaceTransaction(_ original: Transaction, with new: Transaction) async throws {}
+    func deleteTransaction(_ transaction: Transaction) async throws {}
+}
+
+/// Backend that always rejects validation.
+fileprivate struct RejectingBackend: AccountingBackend {
+    var binaryPath: String { "/usr/bin/hledger" }
+    var journalFile: URL { URL(fileURLWithPath: "/tmp/test.journal") }
+    func validateJournal() async throws { throw BackendError.commandFailed("invalid journal") }
+    func version() async throws -> String { "1.0" }
+    func loadTransactions(query: String?, reversed: Bool) async throws -> [Transaction] { [] }
+    func loadDescriptions() async throws -> [String] { [] }
+    func loadAccounts() async throws -> [String] { [] }
+    func loadAccountBalances() async throws -> [(String, String)] { [] }
+    func loadAccountTreeBalances() async throws -> [AccountNode] { [] }
+    func loadCommodities() async throws -> [String] { [] }
+    func loadJournalStats() async throws -> JournalStats { JournalStats(transactionCount: 0, accountCount: 0, commodities: []) }
+    func loadPeriodSummary(period: String?) async throws -> PeriodSummary { PeriodSummary(income: 0, expenses: 0, commodity: "€") }
+    func loadExpenseBreakdown(period: String?, preferredCommodity: String) async throws -> [(String, Decimal, String)] { [] }
+    func loadIncomeBreakdown(period: String?, preferredCommodity: String) async throws -> [(String, Decimal, String)] { [] }
+    func loadLiabilitiesBreakdown(preferredCommodity: String) async throws -> [(String, Decimal, String)] { [] }
+    func loadAssetsBreakdown(preferredCommodity: String) async throws -> [(String, Decimal, String)] { [] }
+    func loadMultiCurrencyAccounts() async throws -> Set<String> { [] }
+    func loadInvestmentPositions() async throws -> [(String, Decimal, String)] { [] }
+    func loadInvestmentCost() async throws -> [String: (Decimal, String)] { [:] }
+    func loadInvestmentMarketValues(pricesFile: URL) async throws -> [String: (Decimal, String)] { [:] }
+    func loadReport(type: ReportType, periodBegin: String?, periodEnd: String?, commodity: String?) async throws -> ReportData { ReportData(title: "") }
+    func loadBudgetReport(period: String) async throws -> [BudgetRow] { [] }
+    func parseCsvImport(csvFile: URL, rulesFile: URL) async throws -> [Transaction] { [] }
+    func validateCsvRules(csvFile: URL, rulesFile: URL) async throws {}
+    func appendTransaction(_ transaction: Transaction) async throws {}
+    func updateTransactionStatus(_ transaction: Transaction, to newStatus: TransactionStatus) async throws {}
+    func replaceTransaction(_ original: Transaction, with new: Transaction) async throws {}
+    func deleteTransaction(_ transaction: Transaction) async throws {}
+}
+
+// MARK: - RuleFileManager shared workflow tests
+
+@Suite("RuleFileManager shared workflow")
+struct RuleFileManagerTests {
+
+    // MARK: writeRules — success path
+
+    @Test func writeRulesWritesExpectedContent() async throws {
+        let dir = try RFMHelpers.makeTempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let main = try RFMHelpers.writeFile("", in: dir, name: "main.journal")
+        let budgetPath = RuleFileManager<BudgetRuleFile>.filePath(for: main)
+        try "".write(to: budgetPath, atomically: true, encoding: .utf8)
+
+        let rule = RFMHelpers.makeBudgetRule()
+        let rules = [rule]
+
+        try await RuleFileManager<BudgetRuleFile>.writeRules(
+            rules, to: budgetPath, journalFile: main, validator: PassingBackend()
+        )
+
+        let written = try String(contentsOf: budgetPath, encoding: .utf8)
+        #expect(written.contains("expenses:food"))
+        #expect(written.contains("€500.00"))
+    }
+
+    @Test func writeRulesRemovesBackupOnSuccess() async throws {
+        let dir = try RFMHelpers.makeTempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let main = try RFMHelpers.writeFile("", in: dir, name: "main.journal")
+        let budgetPath = RuleFileManager<BudgetRuleFile>.filePath(for: main)
+        try "".write(to: budgetPath, atomically: true, encoding: .utf8)
+
+        try await RuleFileManager<BudgetRuleFile>.writeRules(
+            [RFMHelpers.makeBudgetRule()], to: budgetPath, journalFile: main, validator: PassingBackend()
+        )
+
+        let backupPath = budgetPath.appendingPathExtension("bak")
+        #expect(!FileManager.default.fileExists(atPath: backupPath.path))
+    }
+
+    // MARK: writeRules — rollback on validation failure
+
+    @Test func writeRulesRollsBackOriginalContentOnFailure() async throws {
+        let dir = try RFMHelpers.makeTempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let main = try RFMHelpers.writeFile("", in: dir, name: "main.journal")
+        let budgetPath = RuleFileManager<BudgetRuleFile>.filePath(for: main)
+        let originalContent = "~ monthly\n    expenses:food                            €100.00\n    Assets:Budget\n"
+        try originalContent.write(to: budgetPath, atomically: true, encoding: .utf8)
+
+        let newRule = RFMHelpers.makeBudgetRule(account: "expenses:invalid", amount: "999.00")
+        await #expect(throws: (any Error).self) {
+            try await RuleFileManager<BudgetRuleFile>.writeRules(
+                [newRule], to: budgetPath, journalFile: main, validator: RejectingBackend()
+            )
+        }
+
+        let restoredContent = try String(contentsOf: budgetPath, encoding: .utf8)
+        #expect(restoredContent == originalContent)
+    }
+
+    @Test func writeRulesRemovesBackupAfterRollback() async throws {
+        let dir = try RFMHelpers.makeTempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let main = try RFMHelpers.writeFile("", in: dir, name: "main.journal")
+        let budgetPath = RuleFileManager<BudgetRuleFile>.filePath(for: main)
+        try "~ monthly\n    Assets:Budget\n".write(to: budgetPath, atomically: true, encoding: .utf8)
+
+        try? await RuleFileManager<BudgetRuleFile>.writeRules(
+            [RFMHelpers.makeBudgetRule()], to: budgetPath, journalFile: main, validator: RejectingBackend()
+        )
+
+        let backupPath = budgetPath.appendingPathExtension("bak")
+        #expect(!FileManager.default.fileExists(atPath: backupPath.path))
+    }
+
+    // MARK: addRule
+
+    @Test func addRuleCreatesFileAndPersistsRule() async throws {
+        let dir = try RFMHelpers.makeTempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let main = try RFMHelpers.writeFile("", in: dir, name: "main.journal")
+        let rule = RFMHelpers.makeBudgetRule(account: "expenses:rent", amount: "1200.00")
+
+        try await RuleFileManager<BudgetRuleFile>.addRule(rule, journalFile: main, validator: PassingBackend())
+
+        let path = RuleFileManager<BudgetRuleFile>.filePath(for: main)
+        let parsed = RuleFileManager<BudgetRuleFile>.parseRules(at: path)
+        #expect(parsed.count == 1)
+        #expect(parsed[0].account == "expenses:rent")
+    }
+
+    @Test func addRuleDuplicateKeyThrows() async throws {
+        let dir = try RFMHelpers.makeTempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let main = try RFMHelpers.writeFile("", in: dir, name: "main.journal")
+        let rule = RFMHelpers.makeBudgetRule(account: "expenses:food")
+
+        try await RuleFileManager<BudgetRuleFile>.addRule(rule, journalFile: main, validator: PassingBackend())
+
+        await #expect(throws: (any Error).self) {
+            try await RuleFileManager<BudgetRuleFile>.addRule(rule, journalFile: main, validator: PassingBackend())
+        }
+    }
+
+    // MARK: updateRule
+
+    @Test func updateRuleReplacesExistingRule() async throws {
+        let dir = try RFMHelpers.makeTempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let main = try RFMHelpers.writeFile("", in: dir, name: "main.journal")
+        let original = RFMHelpers.makeBudgetRule(account: "expenses:food", amount: "500.00")
+        try await RuleFileManager<BudgetRuleFile>.addRule(original, journalFile: main, validator: PassingBackend())
+
+        let updated = BudgetRule(
+            account: "expenses:food",
+            amount: Amount(commodity: "€", quantity: Decimal(string: "750.00")!)
+        )
+        try await RuleFileManager<BudgetRuleFile>.updateRule(
+            key: "expenses:food", newRule: updated, journalFile: main, validator: PassingBackend()
+        )
+
+        let path = RuleFileManager<BudgetRuleFile>.filePath(for: main)
+        let parsed = RuleFileManager<BudgetRuleFile>.parseRules(at: path)
+        #expect(parsed.count == 1)
+        #expect(parsed[0].amount.quantity == Decimal(string: "750.00")!)
+    }
+
+    @Test func updateRuleNotFoundThrows() async throws {
+        let dir = try RFMHelpers.makeTempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let main = try RFMHelpers.writeFile("include budget.journal\n", in: dir, name: "main.journal")
+        try "".write(
+            to: dir.appendingPathComponent("budget.journal"), atomically: true, encoding: .utf8
+        )
+
+        await #expect(throws: (any Error).self) {
+            try await RuleFileManager<BudgetRuleFile>.updateRule(
+                key: "expenses:nonexistent",
+                newRule: RFMHelpers.makeBudgetRule(),
+                journalFile: main,
+                validator: PassingBackend()
+            )
+        }
+    }
+
+    // MARK: deleteRule
+
+    @Test func deleteRuleRemovesRule() async throws {
+        let dir = try RFMHelpers.makeTempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let main = try RFMHelpers.writeFile("", in: dir, name: "main.journal")
+        try await RuleFileManager<BudgetRuleFile>.addRule(
+            RFMHelpers.makeBudgetRule(account: "expenses:food"), journalFile: main, validator: PassingBackend()
+        )
+        try await RuleFileManager<BudgetRuleFile>.addRule(
+            RFMHelpers.makeBudgetRule(account: "expenses:rent", amount: "1200.00"), journalFile: main, validator: PassingBackend()
+        )
+
+        try await RuleFileManager<BudgetRuleFile>.deleteRule(
+            key: "expenses:food", journalFile: main, validator: PassingBackend()
+        )
+
+        let path = RuleFileManager<BudgetRuleFile>.filePath(for: main)
+        let remaining = RuleFileManager<BudgetRuleFile>.parseRules(at: path)
+        #expect(remaining.count == 1)
+        #expect(remaining[0].account == "expenses:rent")
+    }
+
+    @Test func deleteRuleNotFoundThrows() async throws {
+        let dir = try RFMHelpers.makeTempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let main = try RFMHelpers.writeFile("include budget.journal\n", in: dir, name: "main.journal")
+        try "".write(
+            to: dir.appendingPathComponent("budget.journal"), atomically: true, encoding: .utf8
+        )
+
+        await #expect(throws: (any Error).self) {
+            try await RuleFileManager<BudgetRuleFile>.deleteRule(
+                key: "expenses:nonexistent", journalFile: main, validator: PassingBackend()
+            )
+        }
+    }
+}


### PR DESCRIPTION
Closes #144

## Changes

- New **`RuleFile`** protocol: captures what is unique to each file type — `filename`, `parseRules(from:)`, `formatRules(_:)`, `key(of:)`, and the two error factories (`duplicateError` / `notFoundError`).
- New **`RuleFileManager<F: RuleFile>`**: generic enum holding the shared file workflow that was previously duplicated:
  - `ensureFile(journalFile:)` — create file + inject `include` directive
  - `parseRules(at:)` — read + parse
  - `writeRules(_:to:journalFile:validator:)` — backup → write → validate → rollback on failure
  - `addRule`, `updateRule`, `deleteRule`
- **`BudgetManager`** rewritten: `BudgetRuleFile` implements `RuleFile`; `BudgetManager` becomes a thin wrapper that preserves the existing public API exactly (no callsite changes needed).
- **`RecurringManager`** rewritten: `RecurringRuleFile`  implements `RuleFile`; `RecurringManager` becomes a thin wrapper. The recurring-specific helpers (`generateOccurrences`, `computePending`, `generateTransactions`) remain in `RecurringManager` unchanged.
- New **`RuleFileManagerTests`**: covers the shared write/CRUD workflow once (success path, rollback on validation failure, duplicate key, not-found errors). Existing `BudgetManagerTests` and `RecurringManagerTests` pass without modification.

## Out of scope
File formats and view callsites are unchanged.