### PR TITLE
chore: bump version to 0.2.4

### DIFF
--- a/hledger-macos.xcodeproj/project.pbxproj
+++ b/hledger-macos.xcodeproj/project.pbxproj
@@ -414,7 +414,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 0.2.3;
+				MARKETING_VERSION = 0.2.4;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.thesmokinator.hledger-macos";
 				PRODUCT_NAME = "hledger for Mac";
 				REGISTER_APP_GROUPS = YES;
@@ -448,7 +448,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 0.2.3;
+				MARKETING_VERSION = 0.2.4;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.thesmokinator.hledger-macos";
 				PRODUCT_NAME = "hledger for Mac";
 				REGISTER_APP_GROUPS = YES;


### PR DESCRIPTION
Bump `MARKETING_VERSION` from `0.2.3` to `0.2.4` in both Debug and Release configurations of the hledger-macos target.

The v0.2.4 milestone contained 1 PR:
- #146 (closes #144) — refactor: extract generic `RuleFileManager` from `BudgetManager` / `RecurringManager`

Test count: 352 → 362.