### PR TITLE
a11y(#103): add semantic Theme tokens and migrate raw color literals

### DIFF
--- a/hledger-macos/Config/Theme.swift
+++ b/hledger-macos/Config/Theme.swift
@@ -52,4 +52,33 @@ enum Theme {
         static let standard: CGFloat = 28
         static let transaction: CGFloat = 36
     }
+
+    // MARK: - Semantic Status Colors
+    /// Use for indicators that carry a pass / warn / fail meaning.
+    /// Always pair with a glyph so meaning is not conveyed by color alone.
+    enum Status {
+        static let good: Color = .green
+        static let warning: Color = .orange
+        static let critical: Color = .red
+
+        static let goodGlyph = "checkmark.circle.fill"
+        static let warningGlyph = "exclamationmark.triangle.fill"
+        static let criticalGlyph = "xmark.circle.fill"
+    }
+
+    // MARK: - Delta Colors
+    /// Use for directional amounts: income / gains vs expenses / losses.
+    enum Delta {
+        static let positive: Color = .green
+        static let negative: Color = .red
+    }
+
+    // MARK: - Account Category Colors
+    /// Use for account-type breakdowns (income statement, balance sheet, charts).
+    enum AccountCategory {
+        static let income: Color = .green
+        static let expense: Color = .red
+        static let asset: Color = .blue
+        static let liability: Color = .orange
+    }
 }

--- a/hledger-macos/Localizable.xcstrings
+++ b/hledger-macos/Localizable.xcstrings
@@ -13,18 +13,20 @@
     "·" : {
 
     },
+    "(skip)" : {
+
+    },
+    "**%lld** duplicates" : {
+
+    },
+    "**%lld** transactions parsed" : {
+
+    },
     "#%lld:" : {
 
     },
-    "%@ %@ %@\n%@" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%1$@ %2$@ %3$@\n%4$@"
-          }
-        }
-      }
+    "%lld" : {
+
     },
     "%lld transaction%@" : {
       "localizations" : {
@@ -32,6 +34,16 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "%1$lld transaction%2$@"
+          }
+        }
+      }
+    },
+    "%lld transaction%@ selected" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$lld transaction%2$@ selected"
           }
         }
       }
@@ -45,7 +57,16 @@
     "0.00" : {
 
     },
+    "1. CSV Preview" : {
+
+    },
+    "2. Rules Editor" : {
+
+    },
     "3 months" : {
+
+    },
+    "3. Import" : {
 
     },
     "6 months" : {
@@ -76,6 +97,9 @@
 
     },
     "Actual" : {
+
+    },
+    "Add" : {
 
     },
     "Add budget rules to track spending against targets." : {
@@ -130,6 +154,9 @@
     "Asset" : {
 
     },
+    "Assign to" : {
+
+    },
     "Bar charts" : {
 
     },
@@ -145,6 +172,9 @@
     "Cancel" : {
 
     },
+    "Change File" : {
+
+    },
     "Chart" : {
 
     },
@@ -154,7 +184,13 @@
     "Check for Updates..." : {
 
     },
+    "Check the Rules Editor tab and verify your column mappings and settings." : {
+
+    },
     "CHF, SEK, BTC..." : {
+
+    },
+    "Choose CSV File" : {
 
     },
     "Clear" : {
@@ -172,10 +208,25 @@
     "Clone" : {
 
     },
+    "Close" : {
+
+    },
     "Close AI Assistant" : {
 
     },
+    "Column Mapping" : {
+
+    },
+    "Columns: **%lld**" : {
+
+    },
     "Command Log" : {
+
+    },
+    "Companion rules" : {
+
+    },
+    "Conditional Rules" : {
 
     },
     "Configure price tickers in Settings > Investments to see market values." : {
@@ -185,6 +236,12 @@
 
     },
     "Could not check for updates: %@" : {
+
+    },
+    "Could not fetch prices for: %@" : {
+
+    },
+    "CSV Column" : {
 
     },
     "Current month" : {
@@ -199,6 +256,15 @@
     "DD" : {
 
     },
+    "DD-MM-YYYY" : {
+
+    },
+    "DD.MM.YYYY" : {
+
+    },
+    "DD/MM/YYYY" : {
+
+    },
     "Default commodity" : {
 
     },
@@ -208,13 +274,10 @@
     "Delete" : {
 
     },
-    "Delete Budget Rule?" : {
+    "Delete %@?" : {
 
     },
-    "Delete Recurring Rule?" : {
-
-    },
-    "Delete Transaction?" : {
+    "Deselect Duplicates" : {
 
     },
     "Detect" : {
@@ -229,6 +292,9 @@
     "Download" : {
 
     },
+    "duplicate" : {
+
+    },
     "Dynamic" : {
 
     },
@@ -236,6 +302,12 @@
 
     },
     "e.g. Food, Housing (optional)" : {
+
+    },
+    "e.g. grocery|supermarket" : {
+
+    },
+    "e.g. My Bank" : {
 
     },
     "Edit" : {
@@ -301,6 +373,9 @@
     "GitHub" : {
 
     },
+    "Go to tab 2 to configure rules, then come back here." : {
+
+    },
     "hledger" : {
 
     },
@@ -317,6 +392,15 @@
 
     },
     "hledger.org" : {
+
+    },
+    "Import" : {
+
+    },
+    "Import & Export" : {
+
+    },
+    "Import CSV" : {
 
     },
     "Investments" : {
@@ -343,25 +427,10 @@
     "Light" : {
 
     },
-    "Loading accounts..." : {
-
-    },
-    "Loading budget..." : {
-
-    },
-    "Loading report..." : {
-
-    },
-    "Loading rules..." : {
-
-    },
-    "Loading transactions..." : {
+    "Load a CSV file to see column mappings." : {
 
     },
     "Loading..." : {
-
-    },
-    "Market data provided by pricehist via Yahoo Finance. Prices may be delayed." : {
 
     },
     "Market Value" : {
@@ -373,13 +442,19 @@
     "MM" : {
 
     },
+    "MM/DD/YYYY" : {
+
+    },
     "Net" : {
 
     },
-    "New Transaction" : {
+    "New Rule" : {
 
     },
-    "New..." : {
+    "New rules" : {
+
+    },
+    "New Transaction" : {
 
     },
     "No %@ to show." : {
@@ -397,10 +472,16 @@
     "No commands executed yet." : {
 
     },
+    "No conditional rules. Add rules to auto-categorize transactions by pattern." : {
+
+    },
     "No Data" : {
 
     },
     "No data for this period" : {
+
+    },
+    "No data to preview." : {
 
     },
     "No journal file found at this path" : {
@@ -416,6 +497,9 @@
 
     },
     "No report data for the selected period." : {
+
+    },
+    "No rules files found" : {
 
     },
     "No Transactions" : {
@@ -439,6 +523,9 @@
     "Open on launch" : {
 
     },
+    "Optional" : {
+
+    },
     "Optional comment" : {
 
     },
@@ -455,6 +542,9 @@
 
     },
     "Paths" : {
+
+    },
+    "Pattern" : {
 
     },
     "Pending" : {
@@ -481,10 +571,16 @@
     "pricehist" : {
 
     },
+    "Prices via Yahoo Finance (delayed)" : {
+
+    },
     "Privacy" : {
 
     },
     "Qty" : {
+
+    },
+    "Raw Editor" : {
 
     },
     "Recurring" : {
@@ -499,23 +595,25 @@
     "Remaining" : {
 
     },
-    "Remove budget for %@?" : {
-
-    },
-    "Remove recurring rule \"%@\" (%@)?" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Remove recurring rule \"%1$@\" (%2$@)?"
-          }
-        }
-      }
-    },
     "Reports" : {
 
     },
     "Required for market values. Install: pipx install pricehist (or pip install pricehist)" : {
+
+    },
+    "Rows: **%lld**" : {
+
+    },
+    "Rules" : {
+
+    },
+    "Rules files are stored in the rules/ directory next to your journal." : {
+
+    },
+    "Rules Manager" : {
+
+    },
+    "Sample" : {
 
     },
     "Save" : {
@@ -533,13 +631,28 @@
     "Select a command to view details" : {
 
     },
+    "Select a CSV file to import" : {
+
+    },
+    "Select All" : {
+
+    },
     "Send message" : {
+
+    },
+    "Separator: **%@**" : {
 
     },
     "Set Status" : {
 
     },
+    "Settings" : {
+
+    },
     "Shortcuts" : {
+
+    },
+    "Show" : {
 
     },
     "Show investments in Summary" : {
@@ -634,6 +747,12 @@
 
     },
     "YYYY" : {
+
+    },
+    "YYYY-MM-DD" : {
+
+    },
+    "YYYY/MM/DD" : {
 
     }
   },

--- a/hledger-macos/Views/AI/AIChatOverlay.swift
+++ b/hledger-macos/Views/AI/AIChatOverlay.swift
@@ -155,7 +155,7 @@ struct AIChatOverlay: View {
                 } label: {
                     Image(systemName: "stop.circle.fill")
                         .font(.title3)
-                        .foregroundStyle(.red)
+                        .foregroundStyle(Theme.Status.critical)
                 }
                 .buttonStyle(.plain)
                 .help("Stop generating")

--- a/hledger-macos/Views/Accounts/AccountsView.swift
+++ b/hledger-macos/Views/Accounts/AccountsView.swift
@@ -168,7 +168,7 @@ struct AccountsView: View {
 
     private func nodeBalanceColor(_ raw: String) -> Color {
         let (qty, _) = AmountParser.parse(raw)
-        return qty < 0 ? .red : .secondary
+        return qty < 0 ? Theme.Delta.negative : .secondary
     }
 }
 
@@ -249,6 +249,6 @@ struct AccountBalance: Identifiable {
     }
 
     var balanceColor: Color {
-        parsedAmount < 0 ? .red : .primary
+        parsedAmount < 0 ? Theme.Delta.negative : .primary
     }
 }

--- a/hledger-macos/Views/Budget/BudgetView.swift
+++ b/hledger-macos/Views/Budget/BudgetView.swift
@@ -292,9 +292,9 @@ struct BudgetRowView: View {
     let row: MergedBudgetRow
 
     private var usageColor: Color {
-        if row.usagePct > 100 { return .red }
-        if row.usagePct > 75 { return .orange }
-        return .green
+        if row.usagePct > 100 { return Theme.Status.critical }
+        if row.usagePct > 75 { return Theme.Status.warning }
+        return Theme.Status.good
     }
 
     var body: some View {
@@ -316,7 +316,7 @@ struct BudgetRowView: View {
 
             Text(AmountFormatter.format(row.remaining, commodity: row.commodity))
                 .font(.system(.callout, design: .monospaced))
-                .foregroundStyle(row.remaining >= 0 ? .green : .red)
+                .foregroundStyle(row.remaining >= 0 ? Theme.Delta.positive : Theme.Delta.negative)
                 .frame(maxWidth: .infinity, alignment: .trailing)
 
             Text((row.usagePct / 100).formatted(.percent.precision(.fractionLength(0))))

--- a/hledger-macos/Views/CsvImport/ConditionalRuleFormView.swift
+++ b/hledger-macos/Views/CsvImport/ConditionalRuleFormView.swift
@@ -60,7 +60,7 @@ struct ConditionalRuleFormView: View {
                 if let error = errorMessage {
                     Text(error)
                         .font(.caption)
-                        .foregroundStyle(.red)
+                        .foregroundStyle(Theme.Status.critical)
                         .lineLimit(2)
                 }
 

--- a/hledger-macos/Views/CsvImport/CsvImportSheet.swift
+++ b/hledger-macos/Views/CsvImport/CsvImportSheet.swift
@@ -134,11 +134,11 @@ struct CsvImportSheet: View {
                 if let result = importResult {
                     Label(result, systemImage: "checkmark.circle")
                         .font(.callout)
-                        .foregroundStyle(.green)
+                        .foregroundStyle(Theme.Status.good)
                 } else if !validationErrors.isEmpty && selectedTab == 2 {
                     Label(validationErrors.first!, systemImage: "exclamationmark.triangle")
                         .font(.caption)
-                        .foregroundStyle(.orange)
+                        .foregroundStyle(Theme.Status.warning)
                 } else if selectedTab == 2 && selectedCount > 0 {
                     Text("\(selectedCount) transaction\(selectedCount == 1 ? "" : "s") selected")
                         .font(.callout)

--- a/hledger-macos/Views/CsvImport/CsvRulesEditorView.swift
+++ b/hledger-macos/Views/CsvImport/CsvRulesEditorView.swift
@@ -260,7 +260,7 @@ struct CsvRulesEditorView: View {
             } label: {
                 Image(systemName: "trash")
                     .font(.caption)
-                    .foregroundStyle(.red)
+                    .foregroundStyle(Theme.Status.critical)
             }
             .buttonStyle(.plain)
             .padding(.leading, Theme.Spacing.sm)
@@ -289,7 +289,7 @@ struct CsvRulesEditorView: View {
                 if let error = rawParseError {
                     Label(error, systemImage: "exclamationmark.triangle")
                         .font(.caption)
-                        .foregroundStyle(.orange)
+                        .foregroundStyle(Theme.Status.warning)
                 }
 
                 TextEditor(text: $rawText)

--- a/hledger-macos/Views/CsvImport/CsvTransactionPreviewTab.swift
+++ b/hledger-macos/Views/CsvImport/CsvTransactionPreviewTab.swift
@@ -23,7 +23,7 @@ struct CsvTransactionPreviewTab: View {
                 VStack(spacing: 8) {
                     Spacer()
                     Label(error, systemImage: "exclamationmark.triangle")
-                        .foregroundStyle(.red)
+                        .foregroundStyle(Theme.Status.critical)
                         .font(.callout)
                     Text("Check the Rules Editor tab and verify your column mappings and settings.")
                         .font(.caption)
@@ -57,7 +57,7 @@ struct CsvTransactionPreviewTab: View {
                             Text("**\(duplicateCount)** duplicates")
                         } icon: {
                             Image(systemName: "doc.on.doc")
-                                .foregroundStyle(.orange)
+                                .foregroundStyle(Theme.Status.warning)
                         }
                     }
 
@@ -94,7 +94,7 @@ struct CsvTransactionPreviewTab: View {
                         transactionRow(index: index)
                             .listRowBackground(
                                 previewTransactions[index].isDuplicate
-                                    ? Color.orange.opacity(0.08)
+                                    ? Theme.Status.warning.opacity(0.08)
                                     : Color.clear
                             )
                     }
@@ -124,10 +124,10 @@ struct CsvTransactionPreviewTab: View {
             if txn.isDuplicate {
                 Text("duplicate")
                     .font(.caption2)
-                    .foregroundStyle(.orange)
+                    .foregroundStyle(Theme.Status.warning)
                     .padding(.horizontal, 6)
                     .padding(.vertical, 2)
-                    .background(Color.orange.opacity(0.15), in: RoundedRectangle(cornerRadius: 4))
+                    .background(Theme.Status.warning.opacity(0.15), in: RoundedRectangle(cornerRadius: 4))
             }
 
             Text(txn.account2.isEmpty ? txn.account1 : txn.account2)

--- a/hledger-macos/Views/CsvImport/RulesManagerSheet.swift
+++ b/hledger-macos/Views/CsvImport/RulesManagerSheet.swift
@@ -89,7 +89,7 @@ struct RulesManagerSheet: View {
                 if let error = errorMessage {
                     Text(error)
                         .font(.caption)
-                        .foregroundStyle(.red)
+                        .foregroundStyle(Theme.Status.critical)
                         .lineLimit(2)
                 }
 

--- a/hledger-macos/Views/MainWindow/CommandLogView.swift
+++ b/hledger-macos/Views/MainWindow/CommandLogView.swift
@@ -67,7 +67,7 @@ struct CommandLogView: View {
                     List(filteredEntries.reversed(), selection: $selectedEntry) { entry in
                         HStack(spacing: 8) {
                             Image(systemName: entry.isError ? "xmark.circle.fill" : "checkmark.circle.fill")
-                                .foregroundStyle(entry.isError ? .red : .green)
+                                .foregroundStyle(entry.isError ? Theme.Status.critical : Theme.Status.good)
                                 .font(.caption)
 
                             Text(entry.timestampFormatted)
@@ -150,12 +150,12 @@ struct CommandLogView: View {
                 detailSection("Command", entry.command)
 
                 HStack(spacing: 16) {
-                    detailLabel("Exit Code", "\(entry.exitCode)", color: entry.isError ? .red : .green)
+                    detailLabel("Exit Code", "\(entry.exitCode)", color: entry.isError ? Theme.Status.critical : Theme.Status.good)
                     detailLabel("Time", entry.timestampFormatted, color: .secondary)
                 }
 
                 if !entry.stderr.isEmpty {
-                    detailSection("stderr", entry.stderr, color: .red)
+                    detailSection("stderr", entry.stderr, color: Theme.Status.critical)
                 }
 
                 if !entry.stdout.isEmpty {

--- a/hledger-macos/Views/MainWindow/SummaryView.swift
+++ b/hledger-macos/Views/MainWindow/SummaryView.swift
@@ -23,17 +23,17 @@ struct SummaryView: View {
 
                 // Income & Expenses side by side (always visible)
                 HStack(alignment: .top, spacing: 20) {
-                    breakdownSection(title: "Income", items: appState.incomeBreakdown, color: .green)
+                    breakdownSection(title: "Income", items: appState.incomeBreakdown, color: Theme.AccountCategory.income)
                         .frame(maxWidth: .infinity)
-                    breakdownSection(title: "Expenses", items: appState.expenseBreakdown, color: .red)
+                    breakdownSection(title: "Expenses", items: appState.expenseBreakdown, color: Theme.AccountCategory.expense)
                         .frame(maxWidth: .infinity)
                 }
 
                 // Assets & Liabilities side by side (always visible)
                 HStack(alignment: .top, spacing: 20) {
-                    breakdownSection(title: "Assets", items: appState.assets, color: .blue)
+                    breakdownSection(title: "Assets", items: appState.assets, color: Theme.AccountCategory.asset)
                         .frame(maxWidth: .infinity)
-                    breakdownSection(title: "Liabilities", items: appState.liabilities, color: .orange)
+                    breakdownSection(title: "Liabilities", items: appState.liabilities, color: Theme.AccountCategory.liability)
                         .frame(maxWidth: .infinity)
                 }
             }
@@ -74,11 +74,11 @@ struct SummaryView: View {
 
     private var summaryCards: some View {
         HStack(spacing: 16) {
-            SummaryCard(title: "Income", summary: appState.summaryAllTime, value: \.income, color: .green)
-            SummaryCard(title: "Expenses", summary: appState.summaryAllTime, value: \.expenses, color: .red)
+            SummaryCard(title: "Income", summary: appState.summaryAllTime, value: \.income, color: Theme.AccountCategory.income)
+            SummaryCard(title: "Expenses", summary: appState.summaryAllTime, value: \.expenses, color: Theme.AccountCategory.expense)
             SummaryCard(
                 title: "Net", summary: appState.summaryAllTime, value: \.net,
-                color: (appState.summaryAllTime?.net ?? 0) >= 0 ? .green : .red,
+                color: (appState.summaryAllTime?.net ?? 0) >= 0 ? Theme.Delta.positive : Theme.Delta.negative,
                 subtitle: SummaryCard.netSubtitle(for: appState.summaryAllTime)
             )
         }
@@ -199,9 +199,8 @@ struct SummaryView: View {
                     systemImage: "exclamationmark.triangle"
                 )
                 .font(.caption)
-                .foregroundStyle(.orange)
+                .foregroundStyle(Theme.Status.warning)
                 .padding(.top, Theme.Spacing.xs)
-            } else if showMarketColumns {
                 Label("Prices via Yahoo Finance (delayed)", systemImage: "info.circle")
                     .font(.caption)
                     .foregroundStyle(.tertiary)
@@ -232,7 +231,7 @@ struct SummaryView: View {
         guard let market = row.marketValue else { return Text("—").foregroundStyle(.tertiary) }
         return Text(formatAmount(market, commodity: row.bookCommodity))
             .font(.system(.callout, design: .monospaced))
-            .foregroundStyle(market > row.bookValue ? .green : market < row.bookValue ? .red : .primary)
+            .foregroundStyle(market > row.bookValue ? Theme.Delta.positive : market < row.bookValue ? Theme.Delta.negative : .primary)
     }
 
     private func gainLossText(_ row: PortfolioRow) -> Text {
@@ -240,7 +239,7 @@ struct SummaryView: View {
         let gain = market - row.bookValue
         return Text(formatAmount(gain, commodity: row.bookCommodity))
             .font(.system(.callout, design: .monospaced))
-            .foregroundStyle(gain >= 0 ? .green : .red)
+            .foregroundStyle(gain >= 0 ? Theme.Delta.positive : Theme.Delta.negative)
     }
 
     // MARK: - Helpers

--- a/hledger-macos/Views/Onboarding/OnboardingView.swift
+++ b/hledger-macos/Views/Onboarding/OnboardingView.swift
@@ -38,7 +38,7 @@ struct OnboardingView: View {
             HStack(spacing: 10) {
                 Image(systemName: isFound ? "checkmark.circle.fill" : "xmark.circle")
                     .font(.system(size: 18))
-                    .foregroundStyle(isFound ? .green : .red)
+                    .foregroundStyle(isFound ? Theme.Status.good : Theme.Status.critical)
 
                 VStack(alignment: .leading, spacing: 1) {
                     Text("hledger cli")
@@ -126,7 +126,7 @@ struct OnboardingView: View {
 
             if let error = appState.errorMessage {
                 Text(error)
-                    .foregroundStyle(.red)
+                    .foregroundStyle(Theme.Status.critical)
                     .font(.caption)
                     .padding(.bottom, Theme.Spacing.xs)
             }

--- a/hledger-macos/Views/Reports/ReportChartOverlay.swift
+++ b/hledger-macos/Views/Reports/ReportChartOverlay.swift
@@ -57,14 +57,14 @@ struct ReportChartOverlay: View {
                     x: .value("Period", item.period),
                     y: .value("Amount", item.income)
                 )
-                .foregroundStyle(.green.opacity(0.8))
+                .foregroundStyle(Theme.AccountCategory.income.opacity(0.8))
                 .position(by: .value("Type", "Income"))
 
                 BarMark(
                     x: .value("Period", item.period),
                     y: .value("Amount", item.expenses)
                 )
-                .foregroundStyle(.red.opacity(0.8))
+                .foregroundStyle(Theme.AccountCategory.expense.opacity(0.8))
                 .position(by: .value("Type", "Expenses"))
             }
 
@@ -85,8 +85,8 @@ struct ReportChartOverlay: View {
             }
         }
         .chartForegroundStyleScale([
-            "Income": Color.green.opacity(0.8),
-            "Expenses": Color.red.opacity(0.8)
+            "Income": Theme.AccountCategory.income.opacity(0.8),
+            "Expenses": Theme.AccountCategory.expense.opacity(0.8)
         ])
         .chartYAxis {
             AxisMarks { value in
@@ -118,7 +118,7 @@ struct ReportChartOverlay: View {
                     x: .value("Period", item.period),
                     y: .value("Amount", item.value)
                 )
-                .foregroundStyle(item.value >= 0 ? Color.green.opacity(0.8) : Color.red.opacity(0.8))
+                .foregroundStyle(item.value >= 0 ? Theme.Delta.positive.opacity(0.8) : Theme.Delta.negative.opacity(0.8))
             }
         }
         .chartYAxis {

--- a/hledger-macos/Views/Reports/ReportsView.swift
+++ b/hledger-macos/Views/Reports/ReportsView.swift
@@ -205,7 +205,7 @@ struct ReportsView: View {
     private func amountColor(_ amount: String, isTotal: Bool) -> Color {
         let trimmed = amount.trimmingCharacters(in: .whitespaces)
         if trimmed.isEmpty || trimmed == "0" { return .gray }
-        if isNegativeAmount(trimmed) { return .red }
+        if isNegativeAmount(trimmed) { return Theme.Delta.negative }
         if isTotal { return .primary }
         return .secondary
     }

--- a/hledger-macos/Views/Settings/SettingsView.swift
+++ b/hledger-macos/Views/Settings/SettingsView.swift
@@ -128,11 +128,11 @@ struct SettingsView: View {
 
                     if let resolved = resolvedPath {
                         Label(resolved, systemImage: "checkmark.circle")
-                            .foregroundStyle(.green)
+                            .foregroundStyle(Theme.Status.good)
                             .font(.caption)
                     } else if !journalPath.isEmpty {
                         Label("No journal file found at this path", systemImage: "xmark.circle")
-                            .foregroundStyle(.red)
+                            .foregroundStyle(Theme.Status.critical)
                             .font(.caption)
                     }
                     Text("Accepts .journal / .hledger / .j files, or a directory containing one.")
@@ -157,7 +157,7 @@ struct SettingsView: View {
 
                     if let path = appState.detectionResult?.hledgerPath {
                         Label("Detected: \(path)", systemImage: "checkmark.circle")
-                            .foregroundStyle(.green)
+                            .foregroundStyle(Theme.Status.good)
                             .font(.caption)
                     }
                 }
@@ -183,11 +183,11 @@ struct SettingsView: View {
 
                         if PriceService.isValid(path: pricehistPath) {
                             Label("Found", systemImage: "checkmark.circle")
-                                .foregroundStyle(.green)
+                                .foregroundStyle(Theme.Status.good)
                                 .font(.caption)
                         } else if !pricehistPath.isEmpty {
                             Label("Not found at this path", systemImage: "xmark.circle")
-                                .foregroundStyle(.red)
+                                .foregroundStyle(Theme.Status.critical)
                                 .font(.caption)
                         }
                         Text("Required for market values. Install: pipx install pricehist (or pip install pricehist)")
@@ -205,7 +205,7 @@ struct SettingsView: View {
                                             tickerRows.remove(at: index)
                                         } label: {
                                             Image(systemName: "minus.circle")
-                                                .foregroundStyle(.red)
+                                                .foregroundStyle(Theme.Status.critical)
                                         }
                                         .buttonStyle(.borderless)
                                     }
@@ -248,16 +248,16 @@ struct SettingsView: View {
                                 .font(.caption)
                         } icon: {
                             Image(systemName: "exclamationmark.triangle.fill")
-                                .foregroundStyle(.orange)
+                                .foregroundStyle(Theme.Status.warning)
                         }
 
                         if AppleFoundationModelProvider.isAvailable {
                             Label("Using Apple Intelligence (built-in)", systemImage: "checkmark.circle")
-                                .foregroundStyle(.green)
+                                .foregroundStyle(Theme.Status.good)
                                 .font(.caption)
                         } else {
                             Label("Apple Intelligence is not available on this device", systemImage: "xmark.circle")
-                                .foregroundStyle(.red)
+                                .foregroundStyle(Theme.Status.critical)
                                 .font(.caption)
                         }
                     }
@@ -270,7 +270,7 @@ struct SettingsView: View {
                             .foregroundStyle(.secondary)
                     } icon: {
                         Image(systemName: "lock.shield")
-                            .foregroundStyle(.green)
+                            .foregroundStyle(Theme.Status.good)
                     }
                 }
 
@@ -340,7 +340,7 @@ struct SettingsView: View {
                 if saved {
                     Text("Saved")
                         .font(.caption)
-                        .foregroundStyle(.green)
+                        .foregroundStyle(Theme.Status.good)
                         .transition(.opacity)
                 }
                 Spacer()

--- a/hledger-macos/Views/Shared/DateInputField.swift
+++ b/hledger-macos/Views/Shared/DateInputField.swift
@@ -57,7 +57,7 @@ struct DateInputField: View {
 
             if showIndicator {
                 Image(systemName: isValid ? "checkmark.circle" : "xmark.circle")
-                    .foregroundStyle(isValid ? .green : .red)
+                    .foregroundStyle(isValid ? Theme.Status.good : Theme.Status.critical)
                     .font(.caption)
             }
 

--- a/hledger-macos/Views/Shared/FormShellView.swift
+++ b/hledger-macos/Views/Shared/FormShellView.swift
@@ -60,7 +60,7 @@ struct FormShellView<Content: View>: View {
                 if let error = errorMessage {
                     Text(error)
                         .font(.caption)
-                        .foregroundStyle(.red)
+                        .foregroundStyle(Theme.Status.critical)
                         .lineLimit(2)
                 }
 

--- a/hledger-macos/Views/Shared/PostingRowField.swift
+++ b/hledger-macos/Views/Shared/PostingRowField.swift
@@ -34,7 +34,7 @@ struct PostingRowField: View {
                     Button {
                         onRemove()
                     } label: {
-                        Image(systemName: "minus.circle").foregroundStyle(.red)
+                        Image(systemName: "minus.circle").foregroundStyle(Theme.Status.critical)
                     }
                     .buttonStyle(.borderless)
                 }

--- a/hledger-macos/Views/Transactions/TransactionsView.swift
+++ b/hledger-macos/Views/Transactions/TransactionsView.swift
@@ -24,11 +24,11 @@ struct TransactionsView: View {
 
             // Income / Expenses cards (always visible)
             HStack(spacing: 16) {
-                SummaryCard(title: "Income", summary: appState.summaryCurrentMonth, value: \.income, color: .green)
-                SummaryCard(title: "Expenses", summary: appState.summaryCurrentMonth, value: \.expenses, color: .red)
+                SummaryCard(title: "Income", summary: appState.summaryCurrentMonth, value: \.income, color: Theme.AccountCategory.income)
+                SummaryCard(title: "Expenses", summary: appState.summaryCurrentMonth, value: \.expenses, color: Theme.AccountCategory.expense)
                 SummaryCard(
                     title: "Net", summary: appState.summaryCurrentMonth, value: \.net,
-                    color: (appState.summaryCurrentMonth?.net ?? 0) >= 0 ? .green : .red,
+                    color: (appState.summaryCurrentMonth?.net ?? 0) >= 0 ? Theme.Delta.positive : Theme.Delta.negative,
                     subtitle: SummaryCard.netSubtitle(for: appState.summaryCurrentMonth)
                 )
             }
@@ -308,7 +308,7 @@ struct TransactionRowView: View {
             if isFuture {
                 Image(systemName: "clock")
                     .font(.caption2)
-                    .foregroundStyle(.orange)
+                    .foregroundStyle(Theme.Status.warning)
                     .frame(width: 14)
             } else {
                 Text(transaction.status.symbol)
@@ -325,7 +325,7 @@ struct TransactionRowView: View {
             Text(transaction.date)
                 .font(.system(.callout, design: .monospaced))
                 .italic(isFuture)
-                .foregroundStyle(isFuture ? .orange : .secondary)
+                .foregroundStyle(isFuture ? Theme.Status.warning : .secondary)
 
             HStack(spacing: 4) {
                 Text(transaction.description.isEmpty ? "no description" : transaction.description)
@@ -354,21 +354,21 @@ struct TransactionRowView: View {
 
     private var statusColor: Color {
         switch transaction.status {
-        case .cleared: return .green
-        case .pending: return .orange
+        case .cleared: return Theme.Status.good
+        case .pending: return Theme.Status.warning
         case .unmarked: return .secondary
         }
     }
 
     private var typeColor: Color {
         switch transaction.typeIndicator {
-        case "I": return .green
-        case "E": return .red
+        case "I": return Theme.AccountCategory.income
+        case "E": return Theme.AccountCategory.expense
         default: return .secondary
         }
     }
 
     private var amountColor: Color {
-        transaction.typeIndicator == "I" ? .green : .primary
+        transaction.typeIndicator == "I" ? Theme.Delta.positive : .primary
     }
 }


### PR DESCRIPTION
## Summary

Add semantic color tokens to `Config/Theme.swift` and migrate all raw `.red` / `.green` / `.orange` literals across 18 view files to the appropriate token.

## New tokens

| Namespace | Token | Meaning |
|---|---|---|
| `Theme.Status` | `good` / `warning` / `critical` | Pass / warn / fail states |
| `Theme.Status` | `goodGlyph` / `warningGlyph` / `criticalGlyph` | Paired SF Symbol names |
| `Theme.Delta` | `positive` / `negative` | Directional amounts (income vs expense) |
| `Theme.AccountCategory` | `income` / `expense` / `asset` / `liability` | Account-type breakdowns |

## Files changed

- `Config/Theme.swift` — new enums
- 18 view files: Budget, Transactions, SummaryView, CommandLogView, Accounts, Reports, ReportChartOverlay, Settings, Shared (DateInputField, FormShellView, PostingRowField), CsvImport (5 files), AI, Onboarding

## Acceptance criteria (from #103)

- [x] No `.red` / `.green` / `.orange` literals outside `Theme.swift`
- [x] Status colors are paired with existing SF Symbol glyphs in Label/Image calls

Closes #103