### PR TITLE
ux(#104): Developer Mode toggle - hide Command Log

### DIFF
--- a/hledger-macos/Config/AppConfig.swift
+++ b/hledger-macos/Config/AppConfig.swift
@@ -97,6 +97,12 @@ final class AppConfig {
         set { UserDefaults.standard.set(newValue, forKey: "aiEnabled") }
     }
 
+    /// Whether Developer Mode is enabled (shows Command Log and other debug surfaces).
+    var developerMode: Bool {
+        get { UserDefaults.standard.object(forKey: "developerMode") as? Bool ?? false }
+        set { UserDefaults.standard.set(newValue, forKey: "developerMode") }
+    }
+
     /// Default report type: "is" (Income Statement), "bs" (Balance Sheet), "cf" (Cash Flow).
     var defaultReportType: String {
         get { UserDefaults.standard.string(forKey: "defaultReportType") ?? "is" }

--- a/hledger-macos/Views/Settings/SettingsView.swift
+++ b/hledger-macos/Views/Settings/SettingsView.swift
@@ -21,6 +21,7 @@ struct SettingsView: View {
     @State private var pricehistPath = ""
     @State private var tickerRows: [TickerRow] = []
     @State private var aiEnabled = false
+    @State private var developerMode = false
 
     @State private var resolvedPath: String?
     @State private var isScanning = false
@@ -275,11 +276,18 @@ struct SettingsView: View {
                 }
 
                 Section("Usage") {
-                    Text("When enabled, an AI button appears at the bottom-left of the main window. You can also press \u{2318}\u{21E7}A to toggle the assistant.")
+                    Text("When enabled, an AI button appears at the bottom-left of the main window. You can also press ⌘⇧A to toggle the assistant.")
                         .font(.caption)
                         .foregroundStyle(.secondary)
 
                     Text("The assistant can answer questions about your journal: account balances, spending patterns, transaction summaries, and more.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+
+                Section("Developer") {
+                    Toggle("Developer Mode", isOn: $developerMode)
+                    Text("Shows the Command Log (⌘⌥L) in the Help menu, exposing raw CLI commands and output. Intended for troubleshooting.")
                         .font(.caption)
                         .foregroundStyle(.secondary)
                 }
@@ -376,6 +384,7 @@ struct SettingsView: View {
         barChartMode = appState.config.barChartMode
         investmentsEnabled = appState.config.investmentsEnabled
         aiEnabled = appState.config.aiEnabled
+        developerMode = appState.config.developerMode
         pricehistPath = appState.config.pricehistBinaryPath
         tickerRows = appState.config.priceTickers.map { TickerRow(commodity: $0.key, ticker: $0.value) }
         if tickerRows.isEmpty { tickerRows.append(TickerRow()) }
@@ -416,6 +425,7 @@ struct SettingsView: View {
         appState.config.barChartMode = barChartMode
         appState.config.investmentsEnabled = investmentsEnabled
         appState.config.aiEnabled = aiEnabled
+        appState.config.developerMode = developerMode
         appState.config.pricehistBinaryPath = pricehistPath
         var tickers: [String: String] = [:]
         for row in tickerRows where !row.commodity.isEmpty && !row.ticker.isEmpty {

--- a/hledger-macos/hledger_macosApp.swift
+++ b/hledger-macos/hledger_macosApp.swift
@@ -185,6 +185,7 @@ struct AppCommands: Commands {
                 showingCommandLog = true
             }
             .keyboardShortcut("l", modifiers: [.command, .option])
+            .disabled(!appState.config.developerMode)
         }
 
         SidebarCommands()


### PR DESCRIPTION
## Summary

Adds a **Developer Mode** toggle to Settings that gates access to developer-only surfaces.

### Changes

- AppConfig.swift: new developerMode Bool property backed by UserDefaults key developerMode (default false)
- SettingsView.swift: new Developer section in the AI and Tools tab with a Toggle and explanatory caption; wired into load/save cycle
- hledger_macosApp.swift: Help > Command Log menu item disabled when Developer Mode is off

### Testing

1. Open Settings > AI and Tools > Developer section is visible
2. With Developer Mode off: Help menu shows Command Log grayed out
3. Enable Developer Mode: Command Log becomes clickable and opens the log sheet

Closes #104