### PR TITLE
ux(#107): improve empty states with contextual actions

### DIFF
--- a/hledger-macos/Localizable.xcstrings
+++ b/hledger-macos/Localizable.xcstrings
@@ -102,7 +102,7 @@
     "Add" : {
 
     },
-    "Add budget rules to track spending against targets." : {
+    "Add Budget Rule" : {
 
     },
     "Add Posting" : {
@@ -115,6 +115,15 @@
 
     },
     "Add Ticker" : {
+
+    },
+    "Add Transaction" : {
+
+    },
+    "Add transactions to your journal to generate financial reports." : {
+
+    },
+    "Add your first transaction to start tracking your finances." : {
 
     },
     "Advanced settings" : {
@@ -412,6 +421,9 @@
     "Journal file changed" : {
 
     },
+    "Journal is Empty" : {
+
+    },
     "Keyboard Shortcuts" : {
 
     },
@@ -475,13 +487,16 @@
     "No conditional rules. Add rules to auto-categorize transactions by pattern." : {
 
     },
-    "No Data" : {
+    "No Data for Selected Period" : {
 
     },
     "No data for this period" : {
 
     },
     "No data to preview." : {
+
+    },
+    "No Data to Report" : {
 
     },
     "No journal file found at this path" : {
@@ -496,9 +511,6 @@
     "No Recurring Rules" : {
 
     },
-    "No report data for the selected period." : {
-
-    },
     "No rules files found" : {
 
     },
@@ -508,7 +520,7 @@
     "No transactions found for %@." : {
 
     },
-    "No transactions match your search." : {
+    "No Transactions in %@" : {
 
     },
     "Not found — install with `brew install hledger`" : {
@@ -563,6 +575,9 @@
 
     },
     "Postings" : {
+
+    },
+    "Previous Month" : {
 
     },
     "Price Tickers" : {
@@ -643,6 +658,9 @@
     "Separator: **%@**" : {
 
     },
+    "Set spending targets for your accounts to track budget vs. actual." : {
+
+    },
     "Set Status" : {
 
     },
@@ -656,6 +674,9 @@
 
     },
     "Show investments in Summary" : {
+
+    },
+    "Show Last 12 Months" : {
 
     },
     "Startup" : {
@@ -679,6 +700,9 @@
     "Theme" : {
 
     },
+    "There are no transactions recorded for this period." : {
+
+    },
     "This account has balances in multiple currencies. Only the default currency is shown here. See Accounts for full details." : {
 
     },
@@ -695,6 +719,9 @@
 
     },
     "Tree" : {
+
+    },
+    "Try a longer period range or check that transactions exist for this date range." : {
 
     },
     "Type" : {

--- a/hledger-macos/Views/Budget/BudgetView.swift
+++ b/hledger-macos/Views/Budget/BudgetView.swift
@@ -50,8 +50,11 @@ struct BudgetView: View {
                 ContentUnavailableView(
                     "No Budget Rules",
                     systemImage: "chart.bar",
-                    description: Text("Add budget rules to track spending against targets.")
-                )
+                    description: Text("Set spending targets for your accounts to track budget vs. actual.")
+                ) {
+                    Button("Add Budget Rule") { addRule() }
+                        .buttonStyle(.borderedProminent)
+                }
                 Spacer()
             } else {
                 budgetList

--- a/hledger-macos/Views/Budget/BudgetView.swift
+++ b/hledger-macos/Views/Budget/BudgetView.swift
@@ -47,11 +47,11 @@ struct BudgetView: View {
                 LoadingOverlay(message: "Loading budget...")
             } else if rules.isEmpty {
                 Spacer()
-                ContentUnavailableView(
-                    "No Budget Rules",
-                    systemImage: "chart.bar",
-                    description: Text("Set spending targets for your accounts to track budget vs. actual.")
-                ) {
+                ContentUnavailableView {
+                    Label("No Budget Rules", systemImage: "chart.bar")
+                } description: {
+                    Text("Set spending targets for your accounts to track budget vs. actual.")
+                } actions: {
                     Button("Add Budget Rule") { addRule() }
                         .buttonStyle(.borderedProminent)
                 }

--- a/hledger-macos/Views/Reports/ReportsView.swift
+++ b/hledger-macos/Views/Reports/ReportsView.swift
@@ -54,13 +54,8 @@ struct ReportsView: View {
                         systemImage: "calendar.badge.exclamationmark",
                         description: Text("Try a longer period range or check that transactions exist for this date range.")
                     ) {
-                        Picker("Period", selection: $periodRange) {
-                            ForEach(PeriodRange.allCases) { range in
-                                Text(range.label).tag(range)
-                            }
-                        }
-                        .pickerStyle(.menu)
-                        .fixedSize()
+                        Button("Show Last 12 Months") { periodRange = .twelveMonths }
+                            .buttonStyle(.borderedProminent)
                     }
                 }
                 Spacer()

--- a/hledger-macos/Views/Reports/ReportsView.swift
+++ b/hledger-macos/Views/Reports/ReportsView.swift
@@ -42,11 +42,27 @@ struct ReportsView: View {
                 reportContent(data)
             } else {
                 Spacer()
-                ContentUnavailableView(
-                    "No Data",
-                    systemImage: "doc.text.magnifyingglass",
-                    description: Text("No report data for the selected period.")
-                )
+                if (appState.journalStats?.transactionCount ?? 0) == 0 {
+                    ContentUnavailableView(
+                        "No Data to Report",
+                        systemImage: "doc.text.magnifyingglass",
+                        description: Text("Add transactions to your journal to generate financial reports.")
+                    )
+                } else {
+                    ContentUnavailableView(
+                        "No Data for Selected Period",
+                        systemImage: "calendar.badge.exclamationmark",
+                        description: Text("Try a longer period range or check that transactions exist for this date range.")
+                    ) {
+                        Picker("Period", selection: $periodRange) {
+                            ForEach(PeriodRange.allCases) { range in
+                                Text(range.label).tag(range)
+                            }
+                        }
+                        .pickerStyle(.menu)
+                        .fixedSize()
+                    }
+                }
                 Spacer()
             }
         }

--- a/hledger-macos/Views/Reports/ReportsView.swift
+++ b/hledger-macos/Views/Reports/ReportsView.swift
@@ -49,11 +49,11 @@ struct ReportsView: View {
                         description: Text("Add transactions to your journal to generate financial reports.")
                     )
                 } else {
-                    ContentUnavailableView(
-                        "No Data for Selected Period",
-                        systemImage: "calendar.badge.exclamationmark",
-                        description: Text("Try a longer period range or check that transactions exist for this date range.")
-                    ) {
+                    ContentUnavailableView {
+                        Label("No Data for Selected Period", systemImage: "calendar.badge.exclamationmark")
+                    } description: {
+                        Text("Try a longer period range or check that transactions exist for this date range.")
+                    } actions: {
                         Button("Show Last 12 Months") { periodRange = .twelveMonths }
                             .buttonStyle(.borderedProminent)
                     }

--- a/hledger-macos/Views/Transactions/TransactionsView.swift
+++ b/hledger-macos/Views/Transactions/TransactionsView.swift
@@ -42,13 +42,30 @@ struct TransactionsView: View {
                 LoadingOverlay(message: "Loading transactions...")
             } else if appState.transactions.isEmpty {
                 Spacer()
-                ContentUnavailableView(
-                    "No Transactions",
-                    systemImage: "doc.text",
-                    description: Text(appState.searchQuery.isEmpty
-                        ? "No transactions found for \(appState.periodLabel)."
-                        : "No transactions match your search.")
-                )
+                if !appState.searchQuery.isEmpty {
+                    ContentUnavailableView.search(text: appState.searchQuery)
+                } else if (appState.journalStats?.transactionCount ?? 0) == 0 {
+                    ContentUnavailableView(
+                        "Journal is Empty",
+                        systemImage: "doc.badge.plus",
+                        description: Text("Add your first transaction to start tracking your finances.")
+                    ) {
+                        Button("Add Transaction") { newTransaction() }
+                            .buttonStyle(.borderedProminent)
+                    }
+                } else {
+                    ContentUnavailableView(
+                        "No Transactions in \(appState.periodLabel)",
+                        systemImage: "calendar.badge.exclamationmark",
+                        description: Text("There are no transactions recorded for this period.")
+                    ) {
+                        HStack(spacing: 12) {
+                            Button("Previous Month") { appState.previousMonth() }
+                            Button("Add Transaction") { newTransaction() }
+                                .buttonStyle(.borderedProminent)
+                        }
+                    }
+                }
                 Spacer()
             } else {
                 let todayStr = {

--- a/hledger-macos/Views/Transactions/TransactionsView.swift
+++ b/hledger-macos/Views/Transactions/TransactionsView.swift
@@ -45,20 +45,20 @@ struct TransactionsView: View {
                 if !appState.searchQuery.isEmpty {
                     ContentUnavailableView.search(text: appState.searchQuery)
                 } else if (appState.journalStats?.transactionCount ?? 0) == 0 {
-                    ContentUnavailableView(
-                        "Journal is Empty",
-                        systemImage: "doc.badge.plus",
-                        description: Text("Add your first transaction to start tracking your finances.")
-                    ) {
+                    ContentUnavailableView {
+                        Label("Journal is Empty", systemImage: "doc.badge.plus")
+                    } description: {
+                        Text("Add your first transaction to start tracking your finances.")
+                    } actions: {
                         Button("Add Transaction") { newTransaction() }
                             .buttonStyle(.borderedProminent)
                     }
                 } else {
-                    ContentUnavailableView(
-                        "No Transactions in \(appState.periodLabel)",
-                        systemImage: "calendar.badge.exclamationmark",
-                        description: Text("There are no transactions recorded for this period.")
-                    ) {
+                    ContentUnavailableView {
+                        Label("No Transactions in \(appState.periodLabel)", systemImage: "calendar.badge.exclamationmark")
+                    } description: {
+                        Text("There are no transactions recorded for this period.")
+                    } actions: {
                         HStack(spacing: 12) {
                             Button("Previous Month") { appState.previousMonth() }
                             Button("Add Transaction") { newTransaction() }

--- a/hledger-macos/Views/Transactions/TransactionsView.swift
+++ b/hledger-macos/Views/Transactions/TransactionsView.swift
@@ -59,11 +59,8 @@ struct TransactionsView: View {
                     } description: {
                         Text("There are no transactions recorded for this period.")
                     } actions: {
-                        HStack(spacing: 12) {
-                            Button("Previous Month") { appState.previousMonth() }
-                            Button("Add Transaction") { newTransaction() }
-                                .buttonStyle(.borderedProminent)
-                        }
+                        Button("Add Transaction") { newTransaction() }
+                            .buttonStyle(.borderedProminent)
                     }
                 }
                 Spacer()


### PR DESCRIPTION
## Summary

Replaces generic empty state messages with context-aware views that guide the user to the next action.

### TransactionsView – three distinct states
- Journal empty: 'Journal is Empty' + Add Transaction CTA
- Search no results: native ContentUnavailableView.search(text:)
- Period no results: 'No Transactions in month' + Previous Month + Add Transaction

### BudgetView
- 'No Budget Rules' now includes an Add Budget Rule CTA

### ReportsView – two distinct states
- Journal empty: 'No Data to Report' with guidance to add transactions first
- Period no data: 'No Data for Selected Period' + 'Show Last 12 Months' button

All states use journalStats.transactionCount == 0 to distinguish a truly empty journal from a filtered/period result.

Closes #107