### PR TITLE
ux(#111): misc polish bundle

### DIFF
--- a/hledger-macos/Views/Budget/BudgetView.swift
+++ b/hledger-macos/Views/Budget/BudgetView.swift
@@ -74,6 +74,7 @@ struct BudgetView: View {
                     Label("Export", systemImage: "arrow.down.doc")
                 }
                 .disabled(mergedRows.isEmpty)
+                .help(mergedRows.isEmpty ? "No budget data to export" : "")
 
                 Button { addRule() } label: {
                     Label("Add Rule", systemImage: "plus")

--- a/hledger-macos/Views/Recurring/RecurringView.swift
+++ b/hledger-macos/Views/Recurring/RecurringView.swift
@@ -17,6 +17,7 @@ struct RecurringView: View {
     @State private var showingGenerateConfirm = false
     @State private var pendingSummary: [(RecurringRule, Int)] = []
     @FocusState private var listFocused: Bool
+    @State private var generateToast: String?
 
     var body: some View {
         VStack(spacing: 0) {
@@ -68,6 +69,19 @@ struct RecurringView: View {
             .opacity(0)
         }
         .task(id: appState.dataVersion) { await loadData() }
+        .overlay(alignment: .bottom) {
+            if let toast = generateToast {
+                Text(toast)
+                    .font(.callout)
+                    .padding(.horizontal, Theme.Spacing.lg)
+                    .padding(.vertical, Theme.Spacing.sm)
+                    .background(.regularMaterial, in: Capsule())
+                    .padding(.bottom, Theme.Spacing.xl)
+                    .transition(.move(edge: .bottom).combined(with: .opacity))
+                    .id(toast)
+            }
+        }
+        .animation(.easeInOut(duration: 0.3), value: generateToast)
         .onChange(of: appState.showingNewRecurringRule) {
             if appState.showingNewRecurringRule {
                 appState.showingNewRecurringRule = false
@@ -93,12 +107,7 @@ struct RecurringView: View {
             Button("Cancel", role: .cancel) {}
             Button("Generate") { Task { await generateAll() } }
         } message: {
-            let total = pendingSummary.reduce(0) { $0 + $1.1 }
-            if total == 0 {
-                Text("No pending transactions to generate. All rules are up to date.")
-            } else {
-                Text(generateSummaryText())
-            }
+            Text(generateSummaryText())
         }
     }
 
@@ -188,7 +197,16 @@ struct RecurringView: View {
         }
         pendingSummary = summary
         isGenerating = false
-        showingGenerateConfirm = true
+
+        if summary.isEmpty {
+            generateToast = "All recurring rules are up to date"
+            Task {
+                try? await Task.sleep(for: .seconds(3))
+                generateToast = nil
+            }
+        } else {
+            showingGenerateConfirm = true
+        }
     }
 
     private func generateSummaryText() -> String {
@@ -217,6 +235,15 @@ struct RecurringView: View {
         }
 
         isGenerating = false
+
+        let msg = totalGenerated == 0
+            ? "All recurring rules are up to date"
+            : "Generated \(totalGenerated) transaction\(totalGenerated == 1 ? "" : "s")"
+        generateToast = msg
+        Task {
+            try? await Task.sleep(for: .seconds(3))
+            generateToast = nil
+        }
     }
 
     private func performDelete() async {

--- a/hledger-macos/Views/Reports/ReportChartOverlay.swift
+++ b/hledger-macos/Views/Reports/ReportChartOverlay.swift
@@ -7,6 +7,7 @@ import Charts
 struct ReportChartOverlay: View {
     let reportType: ReportType
     let data: ReportData
+    let commodity: String
     @Environment(\.dismiss) private var dismiss
 
     var body: some View {
@@ -213,9 +214,16 @@ struct ReportChartOverlay: View {
     }
 
     private func formatAxisValue(_ value: Double) -> String {
-        if abs(value) >= 1000 {
-            return "\(Int(value / 1000))k"
+        let symbol = commodity
+        let abs = Swift.abs(value)
+        let formatted: String
+        if abs >= 1_000_000 {
+            formatted = "\(Int(value / 1_000_000))M"
+        } else if abs >= 1000 {
+            formatted = "\(Int(value / 1000))k"
+        } else {
+            formatted = "\(Int(value))"
         }
-        return "\(Int(value))"
+        return "\(symbol)\(formatted)"
     }
 }

--- a/hledger-macos/Views/Reports/ReportsView.swift
+++ b/hledger-macos/Views/Reports/ReportsView.swift
@@ -75,6 +75,7 @@ struct ReportsView: View {
                     Label("Export", systemImage: "arrow.down.doc")
                 }
                 .disabled(reportData == nil || reportData?.rows.isEmpty == true)
+                .help(reportData == nil || reportData?.rows.isEmpty == true ? "No report data to export" : "")
 
                 Button {
                     showingChart = true
@@ -82,6 +83,7 @@ struct ReportsView: View {
                     Label("Chart", systemImage: "chart.bar")
                 }
                 .disabled(reportData == nil || reportData?.rows.isEmpty == true)
+                .help(reportData == nil || reportData?.rows.isEmpty == true ? "Run a report first to view the chart" : "")
 
                 Menu {
                     ForEach(ReportType.allCases, id: \.self) { type in
@@ -140,7 +142,11 @@ struct ReportsView: View {
         }
         .sheet(isPresented: $showingChart) {
             if let data = reportData {
-                ReportChartOverlay(reportType: reportType, data: data)
+                ReportChartOverlay(
+                    reportType: reportType,
+                    data: data,
+                    commodity: appState.config.defaultCommodity
+                )
             }
         }
         .sheet(item: $drillDown) { item in

--- a/hledger-macos/Views/Shared/SummaryCard.swift
+++ b/hledger-macos/Views/Shared/SummaryCard.swift
@@ -39,9 +39,10 @@ struct SummaryCard: View {
             .font(.system(size: 28, weight: .bold, design: .rounded))
             .frame(height: 34)
 
-            Text(subtitle ?? " ")
+            Text(subtitle ?? "")
                 .font(.caption)
                 .foregroundStyle(.secondary)
+                .frame(minHeight: 20, alignment: .top)
         }
         .frame(maxWidth: .infinity, minHeight: 100)
         .padding(.vertical, Theme.Spacing.lg)

--- a/hledger-macos/Views/Transactions/TransactionFormContent.swift
+++ b/hledger-macos/Views/Transactions/TransactionFormContent.swift
@@ -69,7 +69,7 @@ struct TransactionFormContent: View {
                 .padding(.bottom, Theme.Spacing.xs)
 
             Label {
-                Text("Default commodity: ") + Text(defaultCommodity).bold()
+                Text("Default commodity: **\(defaultCommodity)**")
             } icon: {
                 Image(systemName: "tag")
             }

--- a/hledger-macos/Views/Transactions/TransactionsView.swift
+++ b/hledger-macos/Views/Transactions/TransactionsView.swift
@@ -131,11 +131,13 @@ struct TransactionsView: View {
                         Label("Export as CSV", systemImage: "arrow.down.doc")
                     }
                     .disabled(appState.transactions.isEmpty)
+                    .help(appState.transactions.isEmpty ? "No transactions to export" : "")
 
                     Button { ExportService.exportTransactions(appState.transactions, format: .pdf) } label: {
                         Label("Export as PDF", systemImage: "doc.richtext")
                     }
                     .disabled(appState.transactions.isEmpty)
+                    .help(appState.transactions.isEmpty ? "No transactions to export" : "")
                 } label: {
                     Label("Import & Export", systemImage: "doc.badge.gearshape")
                 }


### PR DESCRIPTION
Closes #111

## Changes

- **SummaryCard**: replace space-placeholder with .frame(minHeight:) for consistent subtitle alignment across cards
- **ReportChartOverlay**: prefix Y-axis labels with currency symbol; add M suffix for millions
- **RecurringView**: skip confirm dialog when no transactions are pending — show toast directly instead; toast also shown after successful generate
- **RecurringView**: fix Generate button UX — no pointless confirmation when all rules are up to date
- **TransactionsView / BudgetView / ReportsView**: .help() tooltips on disabled Export and Chart buttons
- **TransactionFormContent**: fix deprecated Text + operator, use markdown string interpolation

Note: item 4 (DateInputField focus auto-advance) was already implemented — no change needed.