### PR TITLE
ux(#110): error banner, Retry button, and animated typing dots in AI chat

### DIFF
--- a/hledger-macos/Services/AIAssistant.swift
+++ b/hledger-macos/Services/AIAssistant.swift
@@ -97,6 +97,20 @@ final class AIAssistant {
         }
     }
 
+    /// Retry the last user message after an error.
+    func retryLast(appState: AppState) {
+        // Drop the failed assistant bubble
+        if let i = messages.lastIndex(where: { $0.role == .assistant }) {
+            messages.remove(at: i)
+        }
+        // Grab and drop the last user message (send() will re-add it)
+        guard let lastUserIndex = messages.lastIndex(where: { $0.role == .user }) else { return }
+        let lastUserContent = messages[lastUserIndex].content
+        messages.remove(at: lastUserIndex)
+        errorMessage = nil
+        send(lastUserContent, appState: appState)
+    }
+
     /// Clear conversation history.
     func clearChat() {
         stop()

--- a/hledger-macos/Views/AI/AIChatBubble.swift
+++ b/hledger-macos/Views/AI/AIChatBubble.swift
@@ -47,12 +47,30 @@ struct AIChatBubble: View {
     private var streamingIndicator: some View {
         HStack(spacing: 3) {
             ForEach(0..<3) { i in
-                Circle()
-                    .fill(.secondary)
-                    .frame(width: 4, height: 4)
-                    .opacity(0.6)
+                AnimatedDot(delay: Double(i) * 0.2)
             }
         }
         .padding(.leading, Theme.Spacing.md)
+    }
+}
+
+private struct AnimatedDot: View {
+    let delay: Double
+    @State private var scale: CGFloat = 0.6
+
+    var body: some View {
+        Circle()
+            .fill(.secondary)
+            .frame(width: 4, height: 4)
+            .scaleEffect(scale)
+            .onAppear {
+                withAnimation(
+                    .easeInOut(duration: 0.5)
+                    .repeatForever(autoreverses: true)
+                    .delay(delay)
+                ) {
+                    scale = 1.0
+                }
+            }
     }
 }

--- a/hledger-macos/Views/AI/AIChatOverlay.swift
+++ b/hledger-macos/Views/AI/AIChatOverlay.swift
@@ -14,6 +14,9 @@ struct AIChatOverlay: View {
         VStack(spacing: 0) {
             header
             Divider()
+            if let error = assistant.errorMessage {
+                errorBanner(error)
+            }
             messageList
             Divider()
             inputBar
@@ -24,6 +27,7 @@ struct AIChatOverlay: View {
         .clipShape(RoundedRectangle(cornerRadius: Theme.Radius.lg))
         .shadow(color: .black.opacity(0.2), radius: 12, x: -4, y: 0)
         .transition(.move(edge: .trailing).combined(with: .opacity))
+        .animation(.easeInOut(duration: 0.2), value: assistant.errorMessage)
         .onAppear { isInputFocused = true }
     }
 
@@ -64,6 +68,43 @@ struct AIChatOverlay: View {
         }
         .padding(.horizontal, Theme.Spacing.lg)
         .padding(.vertical, Theme.Spacing.md)
+    }
+
+    // MARK: - Error Banner
+
+    private func errorBanner(_ message: String) -> some View {
+        HStack(spacing: Theme.Spacing.sm) {
+            Image(systemName: "exclamationmark.triangle.fill")
+                .foregroundStyle(.orange)
+                .font(.callout)
+
+            Text(message)
+                .font(.caption)
+                .foregroundStyle(.primary)
+                .lineLimit(2)
+
+            Spacer()
+
+            Button("Retry") {
+                assistant.retryLast(appState: appState)
+            }
+            .font(.caption.bold())
+            .buttonStyle(.borderless)
+            .foregroundStyle(.tint)
+
+            Button {
+                assistant.errorMessage = nil
+            } label: {
+                Image(systemName: "xmark")
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+            }
+            .buttonStyle(.plain)
+        }
+        .padding(.horizontal, Theme.Spacing.lg)
+        .padding(.vertical, Theme.Spacing.sm)
+        .background(.orange.opacity(0.12))
+        .transition(.move(edge: .top).combined(with: .opacity))
     }
 
     // MARK: - Message List


### PR DESCRIPTION
Closes #110

## Changes
- **AIChatOverlay**: orange error banner appears when the AI backend fails, with Retry (re-sends last message) and dismiss buttons; animates in/out
- **AIAssistant**: new retryLast() method — removes the failed assistant bubble and last user message, clears errorMessage, re-sends
- **AIChatBubble**: typing dots now animate with staggered scale pulse (delays 0 / 0.2 / 0.4s) instead of static circles