### PR TITLE
a11y(#102): accessibility sweep — labels, hints, and hidden decorative elements

### DIFF
--- a/hledger-macos/Localizable.xcstrings
+++ b/hledger-macos/Localizable.xcstrings
@@ -268,6 +268,9 @@
     "Dark" : {
 
     },
+    "Day" : {
+
+    },
     "Default commodity" : {
 
     },
@@ -373,6 +376,9 @@
     "Import CSV" : {
 
     },
+    "Invalid date" : {
+
+    },
     "Investments" : {
 
     },
@@ -418,6 +424,9 @@
     "Market Value" : {
 
     },
+    "Month" : {
+
+    },
     "Monthly budget amount (e.g. 500.00)" : {
 
     },
@@ -431,6 +440,9 @@
 
     },
     "New rules" : {
+
+    },
+    "Next month" : {
 
     },
     "No %@ to show." : {
@@ -505,6 +517,9 @@
     "OK" : {
 
     },
+    "Open AI Assistant" : {
+
+    },
     "Open on launch" : {
 
     },
@@ -544,6 +559,15 @@
     "Portfolio" : {
 
     },
+    "Posting %lld account" : {
+
+    },
+    "Posting %lld amount" : {
+
+    },
+    "Posting %lld comment" : {
+
+    },
     "Posting comment" : {
 
     },
@@ -551,6 +575,9 @@
 
     },
     "Previous Month" : {
+
+    },
+    "Previous month" : {
 
     },
     "Price Tickers" : {
@@ -578,6 +605,9 @@
 
     },
     "Remaining" : {
+
+    },
+    "Remove posting %lld" : {
 
     },
     "Reports" : {
@@ -706,6 +736,9 @@
     "Using Apple Intelligence (built-in)" : {
 
     },
+    "Valid date" : {
+
+    },
     "Version %@" : {
 
     },
@@ -725,6 +758,9 @@
     "View Release" : {
 
     },
+    "View transactions for %@" : {
+
+    },
     "Welcome to hledger for Mac" : {
 
     },
@@ -741,6 +777,9 @@
 
     },
     "Yahoo ticker" : {
+
+    },
+    "Year" : {
 
     },
     "Year to date" : {

--- a/hledger-macos/Views/AI/AIChatBubble.swift
+++ b/hledger-macos/Views/AI/AIChatBubble.swift
@@ -51,6 +51,7 @@ struct AIChatBubble: View {
             }
         }
         .padding(.leading, Theme.Spacing.md)
+        .accessibilityHidden(true)
     }
 }
 

--- a/hledger-macos/Views/AI/AIChatOverlay.swift
+++ b/hledger-macos/Views/AI/AIChatOverlay.swift
@@ -52,6 +52,7 @@ struct AIChatOverlay: View {
                 }
                 .buttonStyle(.plain)
                 .help("Clear conversation")
+                .accessibilityLabel("Clear conversation")
             }
 
             Button {
@@ -65,6 +66,7 @@ struct AIChatOverlay: View {
             }
             .buttonStyle(.plain)
             .keyboardShortcut(.cancelAction)
+            .accessibilityLabel("Close AI Assistant")
         }
         .padding(.horizontal, Theme.Spacing.lg)
         .padding(.vertical, Theme.Spacing.md)
@@ -200,6 +202,7 @@ struct AIChatOverlay: View {
                 }
                 .buttonStyle(.plain)
                 .help("Stop generating")
+                .accessibilityLabel("Stop generating")
             } else {
                 Button {
                     sendMessage()
@@ -211,6 +214,7 @@ struct AIChatOverlay: View {
                 .buttonStyle(.plain)
                 .disabled(inputText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
                 .help("Send message")
+                .accessibilityLabel("Send message")
             }
         }
         .padding(.horizontal, Theme.Spacing.lg)

--- a/hledger-macos/Views/AI/AIToggleButton.swift
+++ b/hledger-macos/Views/AI/AIToggleButton.swift
@@ -29,6 +29,7 @@ struct AIToggleButton: View {
         }
         .buttonStyle(.plain)
         .help(isShowingChat ? "Close AI Assistant" : "AI Assistant")
+        .accessibilityLabel(isShowingChat ? "Close AI Assistant" : "Open AI Assistant")
         .opacity(isAvailable ? 1 : 0.5)
         .disabled(!isAvailable)
     }

--- a/hledger-macos/Views/Budget/BudgetView.swift
+++ b/hledger-macos/Views/Budget/BudgetView.swift
@@ -92,6 +92,7 @@ struct BudgetView: View {
             }
             .frame(width: 0, height: 0)
             .opacity(0)
+            .accessibilityHidden(true)
         }
         .task(id: appState.dataVersion) { await loadData() }
         .onChange(of: currentPeriod) { Task { await loadData() } }
@@ -287,6 +288,7 @@ struct BudgetHeaderRow: View {
         .font(.caption.weight(.medium))
         .foregroundStyle(.secondary)
         .padding(.vertical, ListMetrics.rowPadding)
+        .accessibilityHidden(true)
     }
 }
 
@@ -329,5 +331,15 @@ struct BudgetRowView: View {
                 .frame(width: 60, alignment: .trailing)
         }
         .padding(.vertical, ListMetrics.rowPadding)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(accessibilityDescription)
+    }
+
+    private var accessibilityDescription: String {
+        let usageStatus: String
+        if row.usagePct > 100 { usageStatus = "over budget" }
+        else if row.usagePct > 75 { usageStatus = "near limit" }
+        else { usageStatus = "within budget" }
+        return "\(row.rule.account): budgeted \(AmountFormatter.format(row.budget, commodity: row.commodity)), actual \(AmountFormatter.format(row.actual, commodity: row.commodity)), remaining \(AmountFormatter.format(row.remaining, commodity: row.commodity)), \((row.usagePct / 100).formatted(.percent.precision(.fractionLength(0)))) used, \(usageStatus)"
     }
 }

--- a/hledger-macos/Views/MainWindow/SidebarView.swift
+++ b/hledger-macos/Views/MainWindow/SidebarView.swift
@@ -14,6 +14,7 @@ struct SidebarView: View {
                 Text("\u{2318}\(section.shortcutNumber)")
                     .font(.caption2.monospacedDigit())
                     .foregroundStyle(.tertiary)
+                    .accessibilityHidden(true)
             }
             .tag(section)
         }

--- a/hledger-macos/Views/Recurring/RecurringView.swift
+++ b/hledger-macos/Views/Recurring/RecurringView.swift
@@ -67,6 +67,7 @@ struct RecurringView: View {
             }
             .frame(width: 0, height: 0)
             .opacity(0)
+            .accessibilityHidden(true)
         }
         .task(id: appState.dataVersion) { await loadData() }
         .overlay(alignment: .bottom) {
@@ -313,5 +314,18 @@ struct RecurringRuleRow: View {
             }
         }
         .padding(.vertical, ListMetrics.rowPadding)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(accessibilityDescription)
+    }
+
+    private var accessibilityDescription: String {
+        var parts: [String] = [rule.periodExpr]
+        parts.append(rule.description.isEmpty ? "No description" : rule.description)
+        let accounts = rule.postings.map(\.account).filter { !$0.isEmpty }
+        if !accounts.isEmpty { parts.append(accounts.joined(separator: " to ")) }
+        if let amount = rule.postings.first(where: { !$0.amounts.isEmpty })?.amounts.first {
+            parts.append(AmountFormatter.format(amount.quantity, commodity: amount.commodity))
+        }
+        return parts.joined(separator: ", ")
     }
 }

--- a/hledger-macos/Views/Shared/DateInputField.swift
+++ b/hledger-macos/Views/Shared/DateInputField.swift
@@ -37,6 +37,7 @@ struct DateInputField: View {
                 .textFieldStyle(.roundedBorder)
                 .frame(width: 60)
                 .focused($focused, equals: .year)
+                .accessibilityLabel("Year")
                 .onChange(of: year) { guard !skipAdvance else { return }; filter(&year, max: 4) { focused = .month } }
 
             Text("-").foregroundStyle(.secondary)
@@ -45,6 +46,7 @@ struct DateInputField: View {
                 .textFieldStyle(.roundedBorder)
                 .frame(width: 40)
                 .focused($focused, equals: .month)
+                .accessibilityLabel("Month")
                 .onChange(of: month) { guard !skipAdvance else { return }; filter(&month, max: 2) { focused = .day } }
 
             Text("-").foregroundStyle(.secondary)
@@ -53,12 +55,14 @@ struct DateInputField: View {
                 .textFieldStyle(.roundedBorder)
                 .frame(width: 40)
                 .focused($focused, equals: .day)
+                .accessibilityLabel("Day")
                 .onChange(of: day) { guard !skipAdvance else { return }; filter(&day, max: 2, advance: nil) }
 
             if showIndicator {
                 Image(systemName: isValid ? "checkmark.circle" : "xmark.circle")
                     .foregroundStyle(isValid ? Theme.Status.good : Theme.Status.critical)
                     .font(.caption)
+                    .accessibilityLabel(isValid ? "Valid date" : "Invalid date")
             }
 
             Spacer()

--- a/hledger-macos/Views/Shared/ListStyles.swift
+++ b/hledger-macos/Views/Shared/ListStyles.swift
@@ -22,6 +22,7 @@ struct AccountRow: View {
                 }
                 .buttonStyle(.plain)
                 .padding(.trailing, Theme.Spacing.xsPlus)
+                .accessibilityLabel("View transactions for \(label)")
             }
             Text(label)
                 .font(labelBold ? labelFont.bold() : labelFont)

--- a/hledger-macos/Views/Shared/PeriodNavigator.swift
+++ b/hledger-macos/Views/Shared/PeriodNavigator.swift
@@ -16,6 +16,7 @@ struct PeriodNavigator: View {
             }
             .buttonStyle(.borderless)
             .keyboardShortcut(.leftArrow, modifiers: [])
+            .accessibilityLabel("Previous month")
 
             Spacer()
 
@@ -30,6 +31,7 @@ struct PeriodNavigator: View {
             }
             .buttonStyle(.borderless)
             .keyboardShortcut(.rightArrow, modifiers: [])
+            .accessibilityLabel("Next month")
         }
         .padding(.horizontal, Theme.Spacing.lg)
         .padding(.top, Theme.Spacing.md)

--- a/hledger-macos/Views/Shared/PostingRowField.swift
+++ b/hledger-macos/Views/Shared/PostingRowField.swift
@@ -23,12 +23,14 @@ struct PostingRowField: View {
                     .font(.callout.monospacedDigit())
                     .foregroundStyle(.secondary)
                     .frame(width: indexWidth, alignment: .trailing)
+                    .accessibilityHidden(true)
 
                 AutocompleteField(
                     placeholder: "e.g. expenses:food",
                     text: $account,
                     suggestions: suggestions
                 )
+                .accessibilityLabel("Posting \(index + 1) account")
 
                 if showRemove {
                     Button {
@@ -37,6 +39,7 @@ struct PostingRowField: View {
                         Image(systemName: "minus.circle").foregroundStyle(Theme.Status.critical)
                     }
                     .buttonStyle(.borderless)
+                    .accessibilityLabel("Remove posting \(index + 1)")
                 }
             }
 
@@ -48,10 +51,12 @@ struct PostingRowField: View {
                     .textFieldStyle(.roundedBorder)
                     .font(.system(.callout, design: .monospaced))
                     .frame(minWidth: 140, maxWidth: 240)
+                    .accessibilityLabel("Posting \(index + 1) amount")
 
                 TextField("Posting comment (optional)", text: $comment)
                     .textFieldStyle(.roundedBorder)
                     .foregroundStyle(.secondary)
+                    .accessibilityLabel("Posting \(index + 1) comment")
             }
         }
         .padding(Theme.Spacing.sm)

--- a/hledger-macos/Views/Shared/SortToggleButton.swift
+++ b/hledger-macos/Views/Shared/SortToggleButton.swift
@@ -16,7 +16,6 @@ struct SortToggleButton: View {
 
     var body: some View {
         if let a = modeA, let b = modeB {
-            // Mode toggle: two predefined sort modes
             Button {
                 ascending.toggle()
             } label: {
@@ -26,8 +25,8 @@ struct SortToggleButton: View {
             }
             .buttonStyle(.borderless)
             .help(ascending ? a.label : b.label)
+            .accessibilityLabel(ascending ? a.label : b.label)
         } else {
-            // Direction toggle: ASC/DESC
             Button {
                 ascending.toggle()
             } label: {
@@ -37,6 +36,7 @@ struct SortToggleButton: View {
             }
             .buttonStyle(.borderless)
             .help(ascending ? descLabel : ascLabel)
+            .accessibilityLabel(ascending ? descLabel : ascLabel)
         }
     }
 }

--- a/hledger-macos/Views/Shared/SummaryCard.swift
+++ b/hledger-macos/Views/Shared/SummaryCard.swift
@@ -48,5 +48,16 @@ struct SummaryCard: View {
         .padding(.vertical, Theme.Spacing.lg)
         .padding(.horizontal, Theme.Spacing.xl)
         .background(.quaternary.opacity(0.3), in: RoundedRectangle(cornerRadius: 12))
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(accessibilityText)
+    }
+
+    private var accessibilityText: String {
+        guard let summary else { return "\(title): loading" }
+        var text = "\(title): \(AmountFormatter.format(summary[keyPath: value], commodity: summary.commodity))"
+        if let sub = subtitle, !sub.trimmingCharacters(in: .whitespaces).isEmpty {
+            text += ", \(sub)"
+        }
+        return text
     }
 }

--- a/hledger-macos/Views/Transactions/TransactionsView.swift
+++ b/hledger-macos/Views/Transactions/TransactionsView.swift
@@ -165,6 +165,7 @@ struct TransactionsView: View {
             }
             .frame(width: 0, height: 0)
             .opacity(0)
+            .accessibilityHidden(true)
         }
         .onChange(of: appState.showingNewTransaction) {
             if appState.showingNewTransaction {
@@ -326,17 +327,20 @@ struct TransactionRowView: View {
                     .font(.caption2)
                     .foregroundStyle(Theme.Status.warning)
                     .frame(width: 14)
+                    .accessibilityHidden(true)
             } else {
                 Text(transaction.status.symbol)
                     .font(.system(.callout, design: .monospaced))
                     .foregroundStyle(statusColor)
                     .frame(width: 14)
+                    .accessibilityHidden(true)
             }
 
             Text(transaction.typeIndicator)
                 .font(.system(.caption, design: .monospaced))
                 .foregroundStyle(typeColor)
                 .frame(width: 14)
+                .accessibilityHidden(true)
 
             Text(transaction.date)
                 .font(.system(.callout, design: .monospaced))
@@ -366,6 +370,30 @@ struct TransactionRowView: View {
                 .foregroundStyle(isFuture ? .secondary : amountColor)
         }
         .padding(.vertical, ListMetrics.rowPadding)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(accessibilityDescription)
+    }
+
+    private var accessibilityDescription: String {
+        var parts: [String] = []
+        if isFuture {
+            parts.append("Scheduled")
+        } else {
+            switch transaction.status {
+            case .cleared: parts.append("Cleared")
+            case .pending: parts.append("Pending")
+            case .unmarked: parts.append("Unmarked")
+            }
+        }
+        switch transaction.typeIndicator {
+        case "I": parts.append("income")
+        case "E": parts.append("expense")
+        default: break
+        }
+        parts.append(transaction.date)
+        if !transaction.description.isEmpty { parts.append(transaction.description) }
+        parts.append(transaction.totalAmount)
+        return parts.joined(separator: ", ")
     }
 
     private var statusColor: Color {


### PR DESCRIPTION
Closes #102

## What was done
Full accessibility sweep across all interactive views. Zero `.accessibilityLabel` existed before this PR.

## Changes by priority

### 1. Sidebar
- Keyboard shortcut hints (⌘1…⌘6) hidden from VoiceOver — decorative only

### 2. Navigation & toolbar
- `PeriodNavigator`: chevron buttons labeled "Previous month" / "Next month"
- All views: hidden keyboard shortcut `Button("")` blocks marked `.accessibilityHidden(true)`

### 3. List rows
- `TransactionRowView`: decorative status/type symbols hidden; combined label reads "Cleared, expense, 2026-01-15, Grocery Store, -€45.00"
- `BudgetRowView`: combined label with account, budgeted, actual, remaining, usage %, status (within budget / near limit / over budget)
- `BudgetHeaderRow`: hidden (decorative column headers)
- `RecurringRuleRow`: combined label with period, description, accounts, amount

### 4. Form fields
- `DateInputField`: year/month/day fields labeled; validation icon labeled "Valid date" / "Invalid date"
- `PostingRowField`: index badge hidden; account/amount/comment fields and remove button all labeled

### 5. Status indicators & shared components
- `SummaryCard`: combined label (title + value + subtitle)
- `SortToggleButton`: `.accessibilityLabel` mirrors `.help()` text
- `AccountRow`: drill-down button labeled "View transactions for <account>"

### 6. AI panel
- `AIToggleButton`: labeled "Open AI Assistant" / "Close AI Assistant"
- `AIChatOverlay`: trash, close, stop, send buttons all labeled
- `AIChatBubble`: streaming dots hidden from accessibility