### PR TITLE
Fix form amount using system locale decimal separator

### DIFF
--- a/hledger-macos/Models/Transaction.swift
+++ b/hledger-macos/Models/Transaction.swift
@@ -117,6 +117,22 @@ struct Amount: Codable, Hashable, Sendable {
         AmountFormatter.format(quantity, commodity: commodity)
     }
 
+    /// Format for use in a form input field.
+    /// Uses the system locale (same as the transaction list display) so the
+    /// decimal separator is always consistent — e.g. "€185,00" on it_IT regardless
+    /// of whether the journal stored the amount as "€185" or "€185,00".
+    func formattedForEditing() -> String {
+        let sign = quantity < 0 ? "-" : ""
+        let absStr = AmountFormatter.format(abs(quantity), commodity: commodity)
+        var result = "\(sign)\(absStr)"
+        if let cost = cost {
+            let costSign = cost.quantity < 0 ? "-" : ""
+            let absCostStr = AmountFormatter.format(abs(cost.quantity), commodity: cost.commodity)
+            result += " @@ \(costSign)\(absCostStr)"
+        }
+        return result
+    }
+
     /// Format a decimal value using the supplied `AmountStyle`. Static so the
     /// caller can pass a style that is not necessarily `self.style` — needed
     /// to format a cost annotation that has its own commodity and style.

--- a/hledger-macos/Views/Transactions/TransactionFormState.swift
+++ b/hledger-macos/Views/Transactions/TransactionFormState.swift
@@ -86,7 +86,7 @@ final class TransactionFormState {
             postingRows = txn.postings.map {
                 PostingRow(
                     account: $0.account,
-                    amount: $0.amounts.first.map { $0.formatted() } ?? "",
+                    amount: $0.amounts.first.map { $0.formattedForEditing() } ?? "",
                     comment: $0.comment,
                     balanceAssertion: $0.balanceAssertion
                 )


### PR DESCRIPTION
## Summary

When amounts are stored as integers in the journal (e.g. `€185` with no decimal), hledger outputs `decimalMark: "."` and `precision: 0` in its JSON. The transaction list displayed `€185,00` (via `AmountFormatter` with system locale) but the edit form showed `€185.00` (dot separator), which was inconsistent.

## Changes

- `Amount.formattedForEditing()` now uses `AmountFormatter.format()` (system locale) instead of recreating the amount with hledger's own style — same formatter used by the transaction list
- Handles negative amounts (`-€185,00`) and `@@ cost` annotations correctly

## Fixes
Closes #113